### PR TITLE
Fix ALL error codes and names

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -84,7 +84,7 @@ function checkParams (done) {
   // Client
   this.clientId = body.client_id || query.client_id;
   if (!this.clientId) {
-    return done(error('invalid_request',
+    return done(error('invalid_client',
       'Invalid or missing client_id parameter'));
   }
 

--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var error = require('./error'),
+var error = require('./error')('authCodeGrant'),
   runner = require('./runner'),
   token = require('./token');
 

--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-var error = require('./error'),
+var error = require('./error')('authorise'),
   runner = require('./runner');
 
 module.exports = Authorise;
@@ -67,7 +67,7 @@ function getBearerToken (done) {
       'Only one method may be used to authenticate at a time (Auth header,  ' +
         'GET or POST).'));
   } else if (methodsUsed === 0) {
-    return done(error('invalid_request', 'The access token was not found'));
+    return done(error('unauthorized'));
   }
 
   // Header: http://tools.ietf.org/html/rfc6750#section-2.1

--- a/lib/error.js
+++ b/lib/error.js
@@ -43,6 +43,7 @@ function OAuth2Error (error, description, err) {
   switch (error) {
     case 'invalid_grant':
     case 'invalid_request':
+    case 'unauthorized_client':
     case 'unsupported_grant_type':
       this.code = 400;
       break;

--- a/lib/error.js
+++ b/lib/error.js
@@ -41,15 +41,15 @@ function OAuth2Error (error, description, err) {
   }
 
   switch (error) {
+    case 'invalid_grant':
+    case 'invalid_request':
+      this.code = 400;
+      break;
     case 'invalid_client':
       this.headers = {
         'WWW-Authenticate': 'Basic realm="Service"'
       };
       /* falls through */
-    case 'invalid_grant':
-    case 'invalid_request':
-      this.code = 400;
-      break;
     case 'invalid_token':
       this.code = 401;
       break;

--- a/lib/error.js
+++ b/lib/error.js
@@ -16,16 +16,35 @@
 
 var util = require('util');
 
-module.exports = OAuth2Error;
+module.exports = OAuth2ErrorWrap;
 
 /**
- * Error
+ * OAuth2ErrorWrap
  *
- * @param {Number} code        Numeric error code
+ * Wrap OAuth2Error to allow configurable type
+ *
+ * @param {String} type        Request type
+ */
+function OAuth2ErrorWrap (type) {
+  return function (error, description, err) {
+    return new OAuth2Error(error, description, err, type);
+  }
+}
+
+/**
+ * Expose OAuth2Error
+ */
+OAuth2ErrorWrap.OAuth2Error = OAuth2Error;
+
+/**
+ * OAuth2Error
+ *
  * @param {String} error       Error descripton
  * @param {String} description Full error description
+ * @param {Mixed}  err         Raw error
+ * @param {String} type        Request type
  */
-function OAuth2Error (error, description, err) {
+function OAuth2Error (error, description, err, type) {
   if (!(this instanceof OAuth2Error))
     return new OAuth2Error(error, description, err);
 
@@ -53,6 +72,7 @@ function OAuth2Error (error, description, err) {
       };
       /* falls through */
     case 'invalid_token':
+    case 'unauthorized':
       this.code = 401;
       break;
     case 'server_error':
@@ -60,6 +80,17 @@ function OAuth2Error (error, description, err) {
       break;
     default:
       this.code = 500;
+  }
+
+  if (type === 'authorise') {
+    this.headers = {
+      'WWW-Authenticate': 'Bearer realm="Service"'
+    }
+
+    if (error !== 'unauthorized') {
+      this.headers['WWW-Authenticate'] += ',error="' + error + '"' +
+        ',error_description="' + description + '"';
+    }
   }
 
   this.error = error;

--- a/lib/error.js
+++ b/lib/error.js
@@ -43,6 +43,7 @@ function OAuth2Error (error, description, err) {
   switch (error) {
     case 'invalid_grant':
     case 'invalid_request':
+    case 'unsupported_grant_type':
       this.code = 400;
       break;
     case 'invalid_client':

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -15,7 +15,7 @@
  */
 
 var auth = require('basic-auth'),
-  error = require('./error'),
+  error = require('./error')('grant'),
   runner = require('./runner'),
   token = require('./token');
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -74,8 +74,7 @@ function extractCredentials (done) {
   // Grant type
   this.grantType = this.req.body && this.req.body.grant_type;
   if (!this.grantType) {
-    return done(error('invalid_request',
-      'Invalid or missing grant_type parameter'));
+    return done(error('invalid_request', 'Missing grant_type parameter'));
   } else if (!this.grantType.match(this.config.regex.grantType)) {
     return done(error('unsupported_grant_type', 'Unsupported grant type'));
   }

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -335,7 +335,7 @@ function checkGrantTypeAllowed (done) {
     if (err) return done(error('server_error', false, err));
 
     if (!allowed) {
-      return done(error('invalid_client',
+      return done(error('unauthorized_client',
         'The grant type is unauthorised for this client_id'));
     }
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -212,7 +212,7 @@ function usePasswordGrant (done) {
   var uname = this.req.body.username,
     pword = this.req.body.password;
   if (!uname || !pword) {
-    return done(error('invalid_client',
+    return done(error('invalid_request',
       'Missing parameters. "username" and "password" are required'));
   }
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -73,9 +73,11 @@ function extractCredentials (done) {
 
   // Grant type
   this.grantType = this.req.body && this.req.body.grant_type;
-  if (!this.grantType || !this.grantType.match(this.config.regex.grantType)) {
+  if (!this.grantType) {
     return done(error('invalid_request',
       'Invalid or missing grant_type parameter'));
+  } else if (!this.grantType.match(this.config.regex.grantType)) {
+    return done(error('unsupported_grant_type', 'Unsupported grant type'));
   }
 
   // Extract credentials
@@ -165,8 +167,7 @@ function checkGrantType (done) {
     case 'client_credentials':
       return useClientCredentialsGrant.call(this, done);
     default:
-      done(error('invalid_request',
-        'Invalid grant_type parameter or parameter missing'));
+      done(error('unsupported_grant_type', 'Unsupported grant type'));
   }
 }
 

--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -116,7 +116,8 @@ OAuth2Server.prototype.errorHandler = function () {
   var self = this;
 
   return function (err, req, res, next) {
-    if (!(err instanceof error) || self.passthroughErrors) return next(err);
+    if (!(err instanceof error.OAuth2Error) || self.passthroughErrors)
+      return next(err);
 
     delete err.name;
     delete err.message;
@@ -127,7 +128,7 @@ OAuth2Server.prototype.errorHandler = function () {
     if (err.headers) res.set(err.headers);
     delete err.headers;
 
-    res.status(err.code).send(err);
+    res.status(err.code).send(err.error === 'unauthorized' ? undefined : err);
   };
 };
 

--- a/test/authCodeGrant.js
+++ b/test/authCodeGrant.js
@@ -69,7 +69,8 @@ describe('AuthCodeGrant', function() {
     request(app)
       .post('/authorise')
       .send({ response_type: 'code' })
-      .expect(400, /invalid or missing client_id parameter/i, done);
+      .expect('WWW-Authenticate', 'Basic realm="Service"')
+      .expect(401, /invalid or missing client_id parameter/i, done);
   });
 
   it('should detect no redirect_uri', function (done) {
@@ -99,7 +100,7 @@ describe('AuthCodeGrant', function() {
         redirect_uri: 'http://nightworld.com'
       })
       .expect('WWW-Authenticate', 'Basic realm="Service"')
-      .expect(400, /invalid client credentials/i, done);
+      .expect(401, /invalid client credentials/i, done);
   });
 
   it('should detect mismatching redirect_uri with a string', function (done) {

--- a/test/authorise.js
+++ b/test/authorise.js
@@ -58,7 +58,8 @@ describe('Authorise', function() {
 
     request(app)
       .get('/')
-      .expect(400, /the access token was not found/i, done);
+      .expect('WWW-Authenticate', 'Bearer realm="Service"')
+      .expect(401, '', done);
   });
 
   it('should allow valid token as query param', function (done){

--- a/test/error.js
+++ b/test/error.js
@@ -1,6 +1,6 @@
 var should = require('should');
 
-var OAuth2Error = require('../lib/error');
+var OAuth2Error = require('../lib/error')('test');
 
 describe('OAuth2Error', function() {
 
@@ -32,6 +32,15 @@ describe('OAuth2Error', function() {
     var error = new OAuth2Error('invalid_client');
 
     error.headers.should.eql({ 'WWW-Authenticate': 'Basic realm="Service"' });
+  });
+
+  it('should expose `headers` if type is `authorise`', function () {
+    var OAuth2Error = require('../lib/error')('authorise');
+    var error = new OAuth2Error('invalid_request', 'Invalid Request');
+
+    error.headers.should.eql({
+      'WWW-Authenticate': 'Bearer realm="Service",error="invalid_request",error_description="Invalid Request"'
+    });
   });
 
   it('should expose a status `code`', function () {

--- a/test/errorHandler.js
+++ b/test/errorHandler.js
@@ -44,11 +44,17 @@ var bootstrap = function (oauthConfig) {
 
 describe('Error Handler', function() {
   it('should return an oauth conformat response', function (done) {
-    var app = bootstrap();
+    var app = bootstrap({
+      model: {
+        getAccessToken: function (token, callback) {
+          callback(false, false);
+        }
+      }
+    });
 
     request(app)
-      .get('/')
-      .expect(400)
+      .get('/?access_token=thom')
+      .expect(401)
       .end(function (err, res) {
         if (err) return done(err);
 

--- a/test/grant.extended.js
+++ b/test/grant.extended.js
@@ -60,7 +60,7 @@ describe('Granting with extended grant type', function () {
         client_id: 'thom',
         client_secret: 'nightworld'
       })
-      .expect(400, /invalid grant_type/i, done);
+      .expect(400, /unsupported grant type/i, done);
   });
 
   it('should still detect unsupported grant_type', function (done) {

--- a/test/grant.js
+++ b/test/grant.js
@@ -221,8 +221,7 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect('WWW-Authenticate', 'Basic realm="Service"')
-        .expect(401, /grant type is unauthorised for this client_id/i, done);
+        .expect(400, /grant type is unauthorised for this client_id/i, done);
     });
   });
 

--- a/test/grant.js
+++ b/test/grant.js
@@ -93,7 +93,8 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password' })
-        .expect(400, /invalid or missing client_id parameter/i, done);
+        .expect('WWW-Authenticate', 'Basic realm="Service"')
+        .expect(401, /invalid or missing client_id parameter/i, done);
     });
 
     it('should check client_id matches regex', function (done) {
@@ -107,7 +108,8 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom' })
-        .expect(400, /invalid or missing client_id parameter/i, done);
+        .expect('WWW-Authenticate', 'Basic realm="Service"')
+        .expect(401, /invalid or missing client_id parameter/i, done);
     });
 
     it('should check client_secret exists', function (done) {
@@ -117,7 +119,8 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom' })
-        .expect(400, /missing client_secret parameter/i, done);
+        .expect('WWW-Authenticate', 'Basic realm="Service"')
+        .expect(401, /missing client_secret parameter/i, done);
     });
 
     it('should extract credentials from body', function (done) {
@@ -136,7 +139,7 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, done);
+        .expect(401, done);
     });
 
     it('should extract credentials from header (Basic)', function (done) {
@@ -155,7 +158,8 @@ describe('Grant', function() {
         .post('/oauth/token')
         .send('grant_type=password&username=test&password=invalid')
         .set('Authorization', 'Basic dGhvbTpuaWdodHdvcmxk')
-        .expect(400, done);
+        .expect('WWW-Authenticate', 'Basic realm="Service"')
+        .expect(401, done);
     });
 
     it('should detect unsupported grant_type', function (done) {
@@ -194,7 +198,8 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, /client credentials are invalid/i, done);
+        .expect('WWW-Authenticate', 'Basic realm="Service"')
+        .expect(401, /client credentials are invalid/i, done);
     });
   });
 
@@ -216,7 +221,8 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, /grant type is unauthorised for this client_id/i, done);
+        .expect('WWW-Authenticate', 'Basic realm="Service"')
+        .expect(401, /grant type is unauthorised for this client_id/i, done);
     });
   });
 

--- a/test/grant.js
+++ b/test/grant.js
@@ -73,7 +73,7 @@ describe('Grant', function() {
       request(app)
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
-        .expect(400, /invalid or missing grant_type parameter/i, done);
+        .expect(400, /missing grant_type parameter/i, done);
     });
 
     it('should ensure grant_type is allowed', function (done) {

--- a/test/grant.js
+++ b/test/grant.js
@@ -83,7 +83,7 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password' })
-        .expect(400, /invalid or missing grant_type parameter/i, done);
+        .expect(400, /unsupported grant type/i, done);
     });
 
     it('should check client_id exists', function (done) {
@@ -179,7 +179,7 @@ describe('Grant', function() {
         .post('/oauth/token')
         .set('Content-Type', 'application/x-www-form-urlencoded')
         .send({ grant_type: 'password', client_id: 'thom', client_secret: 'nightworld' })
-        .expect(400, /invalid or missing grant_type/i, done);
+        .expect(400, /unsupported grant type/i, done);
     });
   });
 

--- a/test/lockdown.js
+++ b/test/lockdown.js
@@ -63,7 +63,7 @@ describe('Lockdown pattern', function() {
 
     request(app)
       .get('/private')
-      .expect(400, /access token was not found/i, done);
+      .expect(401, '', done);
   });
 
   it('should pass valid request through authorise', function (done) {


### PR DESCRIPTION
I've started to notice a few possible errors with regards to errors:

 1. `invalid_client` should return a 401
 2. Missing username/password with password grant should be an `invalid_request` not an `invalid_client`
 3. Missing client_id when using auth_code grant should be an `invalid_client` not an `invalid_request`

This would be a breaking change so would go into 2.1 + may be others so wanted to discuss first.

Relevant section of spec: http://tools.ietf.org/html/rfc6749#section-5.2

Will also have a look at how other implementations handle these cases