### PR TITLE
Modified Authorization Grant to accept a GET

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -73,21 +73,21 @@ function checkParams (done) {
   if (!this.req.body) return done(error('invalid_request'));
 
   // Response type
-  this.responseType = this.req.body.response_type;
+  this.responseType = this.req.body.response_type || this.req.query.response_type;
   if (this.responseType !== 'code') {
     return done(error('invalid_request',
       'Invalid response_type parameter (must be "code")'));
   }
 
   // Client
-  this.clientId = this.req.body.client_id;
+  this.clientId = this.req.body.client_id || this.req.query.client_id;
   if (!this.clientId) {
     return done(error('invalid_request',
       'Invalid or missing client_id parameter'));
   }
 
   // Redirect URI
-  this.redirectUri = this.req.body.redirect_uri;
+  this.redirectUri = this.req.body.redirect_uri || this.req.query.redirect_uri;
   if (!this.redirectUri) {
     return done(error('invalid_request',
       'Invalid or missing redirect_uri parameter'));


### PR DESCRIPTION
The RFC Spec for OAuth 2 specifies that the Authorization Grant endpoint be a HTTP GET.  POST is allowed to be supported, but GET must be implemented according to the spec.  This change modifies authCodeGrant.js to look for the appropriate parameters in either the query string or the body, so HTTP GET and HTTP POST are both supported.

Added tests to test/authCodeGrant.js to test both POST and GET functionality.
