### PR TITLE
Support custom loggers

### DIFF
--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -37,7 +37,7 @@ function OAuth2Server (config) {
 
   this.grants = config.grants || [];
   this.debug = config.debug || function () {};
-  if (typeof(this.debug) !== 'function') {
+  if (typeof this.debug !== 'function') {
       this.debug = console.log;
   }
   this.passthroughErrors = config.passthroughErrors;


### PR DESCRIPTION
I'd like the option to use my own logger, like `winston`.

There doesn't appear to be any behavior changes attached to `config.debug`, and it's only used for logging purposes. To avoid breaking changes, I am using this field to also set custom loggers. Unless `config.debug` is a function, the logging will function exactly as it did before.

I would prefer to use a property that is a little more descriptive instead, like `config.logging`, however that would not be backwards compatible.
