### PR TITLE
Added ability for client to have multiple redirect URIs which are valid.

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -111,7 +111,7 @@ function checkClient (done) {
 
     if (!client) {
       return done(error('invalid_client', 'Invalid client credentials'));
-    } else if (client.redirectUri instanceof Array) {
+    } else if (Array.isArray(client.redirectUri)) {
       if (client.redirectUri.indexOf(self.redirectUri) === -1) {
         return done(error('invalid_request', 'redirect_uri does not match'));
       }

--- a/test/authCodeGrant.js
+++ b/test/authCodeGrant.js
@@ -101,7 +101,7 @@ describe('AuthCodeGrant', function() {
       .expect(400, /invalid client credentials/i, done);
   });
 
-  it('should detect mismatching redirect_uri', function (done) {
+  it('should detect mismatching redirect_uri with a string', function (done) {
     var app = bootstrap({
       getClient: function (clientId, clientSecret, callback) {
         callback(false, {
@@ -161,7 +161,7 @@ describe('AuthCodeGrant', function() {
       .expect(302, /Moved temporarily/i, done);
   });
 
-  it('should accept a valid redirect_uri stringy', function (done) {
+  it('should accept a valid redirect_uri with a string', function (done) {
     var app = bootstrap({
       getClient: function (clientId, clientSecret, callback) {
         callback(false, {


### PR DESCRIPTION
The OAuth 2 spec envisions that an individual client can have several redirect URIs that are valid for a given clientId.  This change allows the redirect_uri returned from the model to be either a string or an array.  Added test for an invalid URI when multiple URIs are returned.  Also added tests for valid URIs when either a string or an Array is returned from getClient.
