### PR TITLE
Update OAuth2Error to inherit from base error

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+var util = require('util');
+
 module.exports = OAuth2Error;
 
 /**
@@ -24,9 +26,19 @@ module.exports = OAuth2Error;
  * @param {String} description Full error description
  */
 function OAuth2Error (error, description, err) {
-
   if (!(this instanceof OAuth2Error))
     return new OAuth2Error(error, description, err);
+
+  Error.call(this);
+
+  this.name = this.constructor.name;
+  if (err instanceof Error) {
+    this.message = err.message;
+    this.stack = err.stack;
+  } else {
+    this.message = description;
+    Error.captureStackTrace(this, this.constructor);
+  }
 
   switch (error) {
     case 'invalid_client':
@@ -50,5 +62,6 @@ function OAuth2Error (error, description, err) {
 
   this.error = error;
   this.error_description = description || error;
-  this.stack = (err && err.stack) || err;
 }
+
+util.inherits(OAuth2Error, Error);

--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -115,6 +115,9 @@ OAuth2Server.prototype.errorHandler = function () {
   return function (err, req, res, next) {
     if (!(err instanceof error) || self.passthroughErrors) return next(err);
 
+    delete err.name;
+    delete err.message;
+
     if (self.debug) console.log(err.stack || err);
     delete err.stack;
 

--- a/test/error.js
+++ b/test/error.js
@@ -1,0 +1,68 @@
+var should = require('should');
+
+var OAuth2Error = require('../lib/error');
+
+describe('OAuth2Error', function() {
+
+  it('should be an instance of `Error`', function () {
+    var error = new OAuth2Error('invalid_request', 'The access token was not found');
+
+    error.should.be.instanceOf(Error);
+  });
+
+  it('should expose the `message` as the description', function () {
+    var error = new OAuth2Error('invalid_request', 'The access token was not found');
+
+    error.message.should.equal('The access token was not found');
+  });
+
+  it('should expose the `stack`', function () {
+    var error = new OAuth2Error('invalid_request', 'The access token was not found');
+
+    error.stack.should.not.be.undefined;
+  });
+
+  it('should expose a custom `name`', function () {
+    var error = new OAuth2Error();
+
+    error.name.should.equal('OAuth2Error');
+  });
+
+  it('should expose `headers` if error is `invalid_client`', function () {
+    var error = new OAuth2Error('invalid_client');
+
+    error.headers.should.eql({ 'WWW-Authenticate': 'Basic realm="Service"' });
+  });
+
+  it('should expose a status `code`', function () {
+    var error = new OAuth2Error('invalid_client');
+
+    error.code.should.be.a.Number;
+  });
+
+  it('should expose the `error`', function () {
+    var error = new OAuth2Error('invalid_client');
+
+    error.error.should.equal('invalid_client');
+  });
+
+  it('should expose the `error_description`', function () {
+    var error = new OAuth2Error('invalid_client', 'The access token was not found');
+
+    error.error_description.should.equal('The access token was not found');
+  });
+
+  it('should expose the `stack` of a previous error', function () {
+    var error = new OAuth2Error('invalid_request', 'The access token was not found', new Error());
+
+    error.stack.should.not.match(/^OAuth2Error/);
+    error.stack.should.match(/^Error/);
+  });
+
+  it('should expose the `message` of a previous error', function () {
+    var error = new OAuth2Error('invalid_request', 'The access token was not found', new Error('foo'));
+
+    error.message.should.equal('foo');
+  });
+
+});


### PR DESCRIPTION
OAuth2Error looks like an error, behaves like an error but it's not
actually an error. This can lead to all sorts of erratic behavior if one
expects it to be an instance of Error. These changes are fully
backwards-compatible. The error handler has been updated to keep the
error response compliant with a typical OAuth response.

Several tests have also been added to the error class.
