### PR TITLE
Corrected Refresh Token array in memory

### DIFF
--- a/examples/memory/model.js
+++ b/examples/memory/model.js
@@ -14,7 +14,7 @@ var oauthAccessTokens = [],
     password: [
       'thom'
     ],
-    refreshToken: [
+    refresh_token: [
       'thom'
     ]
   },


### PR DESCRIPTION
The array name in memory has been corrected for the example. It lead to an error saying client_id did not have permission for the refresh_token grant type.
