### PR TITLE
Fix authCodeGrant bug.

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -115,12 +115,11 @@ function checkClient (done) {
       if (client.redirectUri.indexOf(self.redirectUri) === -1) {
         return done(error('invalid_request', 'redirect_uri does not match'));
       }
+      client.redirectUri = self.redirectUri;
     } else if (client.redirectUri !== self.redirectUri) {
       return done(error('invalid_request', 'redirect_uri does not match'));
     }
 
-    // Make the request redirectUri as the client's redirectUri
-    client.redirectUri = self.redirectUri;
     // The request contains valid params so any errors after this point
     // are redirected to the redirect_uri
     self.res.oauthRedirect = true;


### PR DESCRIPTION
Make the request redirectUri as the client's redirectUri.
This is correct when client.redirectUri is an Array type.
