### PR TITLE
memory model typo fixing

### DIFF
--- a/examples/memory/model.js
+++ b/examples/memory/model.js
@@ -63,7 +63,7 @@ model.getClient = function (clientId, clientSecret, callback) {
   for(var i = 0, len = oauthClients.length; i < len; i++) {
     var elem = oauthClients[i];
     if(elem.clientId === clientId &&
-      (clientSecret === null || elem.client_secret === clientSecret)) {
+      (clientSecret === null || elem.clientSecret === clientSecret)) {
       return callback(false, elem);
     }
   }


### PR DESCRIPTION
there were typo in getClient
      (clientSecret === null || elem.client_secret === clientSecret)) {
but field is named differently in model:
  oauthClients = [
    {
      clientId : 'thom',
      clientSecret : 'nightworld',
      redirectUri : ''
    }
  ],
