### PR TITLE
Update Readme "extendedGrant" function signature

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -215,7 +215,9 @@ The spec does not actually require that you revoke the old token - hence this is
 
 ### Required for [extension grant](#extension-grants) grant type
 
-#### extendedGrant (req, callback)
+#### extendedGrant (grantType, req, callback)
+- *string* **grantType**
+ - The (custom) grant type
 - *object* **req**
  - The raw request
 - *function* **callback (error, supported, user)**
@@ -247,7 +249,7 @@ The spec does not actually require that you revoke the old token - hence this is
 ## Extension Grants
 You can support extension/custom grants by implementing the extendedGrant method as outlined above.
 Any requests that begin with http(s):// (as [defined in the spec](http://tools.ietf.org/html/rfc6749#section-4.5)) will be passed to it for you to handle.
-You can access the grant type via req.oauth.grantType and you should pass back supported as `false` if you do not support it to ensure a consistent (and compliant) response.
+You can access the grant type via the first argument and you should pass back supported as `false` if you do not support it to ensure a consistent (and compliant) response.
 
 ## Example using the `password` grant type
 


### PR DESCRIPTION
The `extendedGrant` function signature in the Readme documentation does not reflect the implementation in `grant.js`:

```
function useExtendedGrant (done) {
  var self = this;
  this.model.extendedGrant(this.grantType, this.req,
      function (err, supported, user) {
```

I updated the docs to include the first parameter, `grantType`.

Cheers,
Steffen
