### PR TITLE
Added 'state' to authorization response as required by RFC 6749

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -188,7 +188,8 @@ function saveAuthCode (done) {
  * @this   OAuth
  */
 function redirect (done) {
-  this.res.redirect(this.client.redirectUri + '?code=' + this.authCode);
+  this.res.redirect(this.client.redirectUri + '?code=' + this.authCode +
+      (this.req.query.state ? '&state=' + this.req.query.state : ''));
 
   if (this.config.continueAfterResponse)
     return done();

--- a/test/authCodeGrant.js
+++ b/test/authCodeGrant.js
@@ -290,6 +290,37 @@ describe('AuthCodeGrant', function() {
       });
   });
 
+  it('should accept valid request and return code and state using GET', function (done) {
+    var code;
+
+    var app = bootstrap({
+      getClient: function (clientId, clientSecret, callback) {
+        callback(false, {
+          clientId: 'thom',
+          redirectUri: 'http://nightworld.com'
+        });
+      },
+      saveAuthCode: function (authCode, clientId, expires, user, callback) {
+        should.exist(authCode);
+        code = authCode;
+        callback();
+      }
+    }, [false, true]);
+
+    request(app)
+      .get('/authorise')
+      .query({
+        response_type: 'code',
+        client_id: 'thom',
+        redirect_uri: 'http://nightworld.com',
+        state: 'some_state'
+      })
+      .expect(302, function (err, res) {
+        res.header.location.should.equal('http://nightworld.com?code=' + code  + '&state=some_state');
+        done();
+      });
+  });
+
   it('should continue after success response if continueAfterResponse = true', function (done) {
     var app = bootstrap({
       getClient: function (clientId, clientSecret, callback) {


### PR DESCRIPTION
From RFC 6749, section 4.1.2 (http://tools.ietf.org/html/rfc6749#section-4.1.2):
      state
           REQUIRED if the "state" parameter was present in the client
           authorization request.  The exact value received from the
           client.

I've added this functionality and a test.
