### PR TITLE
res.send(status, body) -> res.status(status).send(body)

### DIFF
--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -127,7 +127,7 @@ OAuth2Server.prototype.errorHandler = function () {
     if (err.headers) res.set(err.headers);
     delete err.headers;
 
-    res.send(err.code, err);
+    res.status(err.code).send(err);
   };
 };
 


### PR DESCRIPTION
express deprecated res.send(status, body): Use res.status(status).send(body) instead at node_modules\oauth2-server\lib\oauth2server.js:130:9
