### PR TITLE
Fix README getRefreshToken to correctly document

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -188,8 +188,8 @@ Note: see https://github.com/thomseddon/node-oauth2-server/tree/master/examples/
 
 #### getRefreshToken (refreshToken, callback)
 - *string* **refreshToken**
- - The bearer token (access token) that has been provided
-- *function* **callback (error, accessToken)**
+ - The bearer token (refresh token) that has been provided
+- *function* **callback (error, refreshToken)**
  - *mixed* **error**
      - Truthy to indicate an error
  - *object* **refreshToken**


### PR DESCRIPTION
https://github.com/thomseddon/node-oauth2-server/issues/110

Update the README to reflect the correct returns of `getAccessToken(refreshToken, callback)`
