### PR TITLE
Pass the mode.generateToken function the grant as its first argument

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+.idea

--- a/lib/token.js
+++ b/lib/token.js
@@ -23,12 +23,13 @@ module.exports = Token;
  * Token generator that will delegate to model or
  * the internal random generator
  *
+ * @param  {Object}   grant    the Grant instance (see grant.js)
  * @param  {String}   type     'accessToken' or 'refreshToken'
  * @param  {Function} callback
  */
-function Token (config, type, callback) {
-  if (config.model.generateToken) {
-    config.model.generateToken(type, config.req, function (err, token) {
+function Token (grant, type, callback) {
+  if (grant.model.generateToken) {
+    grant.model.generateToken(type, grant, function (err, token) {
       if (err) return callback(error('server_error', false, err));
       if (!token) return generateRandomToken(callback);
       callback(false, token);

--- a/test/token.js
+++ b/test/token.js
@@ -1,0 +1,88 @@
+/**
+ * Copyright 2013-present NightWorld.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var Token  = require('../lib/token'),
+    error = require('../lib/error')
+    should = require('should');
+
+describe('Token generator', function() {
+
+  describe('model.generateToken not defined', function() {
+
+    it('Generates random token', function (done) {
+      model = {generateToken: null};
+      grant = {model: model};
+      Token(grant, 'token_type', function (err, token) {
+        token.should.not.be.null;
+        done();
+      });
+    });
+
+  });
+
+  describe('model.generateToken is defined', function() {
+
+    it('Returns token from model.generateToken', function (done) {
+      var generatedToken = 'generateToken.token';
+
+      var generateToken = function (type, grant, cb) {
+        type.should.be.equal('token_type');
+        grant.model.should.be.equal(model);
+        cb(null, generatedToken)
+      };
+
+      model = {generateToken: generateToken};
+      grant = {model: model};
+
+      Token(grant, 'token_type', function (err, token) {
+        token.should.be.equal(generatedToken);
+        done();
+      });
+    });
+
+    it('Generates random token if model.generateToken does not return a token ', function (done) {
+      var generateToken = function (type, grant, cb) {
+        cb(null, null)
+      };
+
+      model = {generateToken: generateToken};
+      grant = {model: model};
+
+      Token(grant, 'token_type', function (err, token) {
+        token.should.not.be.null;
+        done();
+      });
+    });
+
+    it('Returns wrapped error from model.generateToken', function (done) {
+      var generatedError = new Error('generateToken.error');
+
+      var generateToken = function (type, grant, cb) {
+        cb(generatedError)
+      };
+
+      model = {generateToken: generateToken};
+      grant = {model: model};
+
+      Token(grant, 'token_type', function (err, token) {
+        err.should.eql(error('server_error', false, generatedError));
+        done();
+      });
+    });
+
+  });
+
+});


### PR DESCRIPTION
This is to address https://github.com/thomseddon/node-oauth2-server/issues/131.

Pass the mode.generateToken function the grant as its first argument instead of just the grant.req. This allows for JWT generators to have access to the user and client for populating claims.
