### PR TITLE
Fixes #98 - Addes client-specific token lifetimes

### DIFF
--- a/lib/authCodeGrant.js
+++ b/lib/authCodeGrant.js
@@ -116,6 +116,7 @@ function checkClient (done) {
         return done(error('invalid_request', 'redirect_uri does not match'));
       }
       client.redirectUri = self.redirectUri;
+
     } else if (client.redirectUri !== self.redirectUri) {
       return done(error('invalid_request', 'redirect_uri does not match'));
     }
@@ -172,7 +173,11 @@ function generateCode (done) {
  */
 function saveAuthCode (done) {
   var expires = new Date();
-  expires.setSeconds(expires.getSeconds() + this.config.authCodeLifetime);
+
+  var ttl = !isNaN(parseFloat(this.client.authCodeLifetime)) && isFinite(this.client.authCodeLifetime) ?
+    this.client.authCodeLifetime : this.config.authCodeLifetime;
+
+  expires.setSeconds(expires.getSeconds() + ttl);
 
   this.model.saveAuthCode(this.authCode, this.client.clientId, expires,
       this.user, function (err) {

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -132,13 +132,17 @@ function credsFromBody (req) {
  * @this   OAuth
  */
 function checkClient (done) {
-  this.model.getClient(this.client.clientId, this.client.clientSecret,
+  var self = this;
+  self.model.getClient(self.client.clientId, self.client.clientSecret,
       function (err, client) {
     if (err) return done(error('server_error', false, err));
 
     if (!client) {
       return done(error('invalid_client', 'Client credentials are invalid'));
     }
+
+    self.client.accessTokenLifetime = client.accessTokenLifetime;
+    self.client.refreshTokenLifetime = client.refreshTokenLifetime;
 
     done();
   });
@@ -390,9 +394,13 @@ function saveAccessToken (done) {
   }
 
   var expires = null;
-  if (this.config.accessTokenLifetime !== null) {
+
+  var ttl = !isNaN(parseFloat(this.client.accessTokenLifetime)) && isFinite(this.client.accessTokenLifetime) ?
+    this.client.accessTokenLifetime : this.config.accessTokenLifetime;
+
+  if (ttl !== null) {
     expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + this.config.accessTokenLifetime);
+    expires.setSeconds(expires.getSeconds() + ttl);
   }
 
   this.model.saveAccessToken(accessToken, this.client.clientId, expires,
@@ -436,9 +444,18 @@ function saveRefreshToken (done) {
   }
 
   var expires = null;
-  if (this.config.refreshTokenLifetime !== null) {
+
+  var ttl = !isNaN(parseFloat(this.client.refreshTokenLifetime)) && isFinite(this.client.refreshTokenLifetime) ?
+    this.client.refreshTokenLifetime : this.config.refreshTokenLifetime;
+
+  if (ttl !== null) {
     expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + this.config.refreshTokenLifetime);
+    expires.setSeconds(expires.getSeconds() + ttl);
+  }
+
+  if (ttl !== null) {
+    expires = new Date(this.now);
+    expires.setSeconds(expires.getSeconds() + ttl);
   }
 
   this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -57,6 +57,20 @@ function Grant (config, req, res, next) {
   runner(fns, this, next);
 }
 
+Grant.prototype.setExpires = function (key) {
+
+  var expires = null;
+
+  var ttl = !isNaN(parseFloat(this.client[key])) && isFinite(this.client[key]) ? this.client[key]: this.config[key];
+
+  if (ttl !== null) {
+    expires = new Date(this.now);
+    expires.setSeconds(expires.getSeconds() + ttl);
+  }
+
+  return expires;
+};
+
 /**
  * Basic request validation and extraction of grant_type and client creds
  *
@@ -393,15 +407,7 @@ function saveAccessToken (done) {
     return done();
   }
 
-  var expires = null;
-
-  var ttl = !isNaN(parseFloat(this.client.accessTokenLifetime)) && isFinite(this.client.accessTokenLifetime) ?
-    this.client.accessTokenLifetime : this.config.accessTokenLifetime;
-
-  if (ttl !== null) {
-    expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + ttl);
-  }
+  var expires = this.setExpires("accessTokenLifetime");
 
   this.model.saveAccessToken(accessToken, this.client.clientId, expires,
       this.user, function (err) {
@@ -443,20 +449,7 @@ function saveRefreshToken (done) {
     return done();
   }
 
-  var expires = null;
-
-  var ttl = !isNaN(parseFloat(this.client.refreshTokenLifetime)) && isFinite(this.client.refreshTokenLifetime) ?
-    this.client.refreshTokenLifetime : this.config.refreshTokenLifetime;
-
-  if (ttl !== null) {
-    expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + ttl);
-  }
-
-  if (ttl !== null) {
-    expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + ttl);
-  }
+  var expires = this.setExpires("accessTokenLifetime");
 
   this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,
       this.user, function (err) {

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -449,7 +449,7 @@ function saveRefreshToken (done) {
     return done();
   }
 
-  var expires = this.setExpires("accessTokenLifetime");
+  var expires = this.setExpires("refreshTokenLifetime");
 
   this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,
       this.user, function (err) {

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -61,11 +61,11 @@ Grant.prototype.setExpires = function (key) {
 
   var expires = null;
 
-  var ttl = !isNaN(parseFloat(this.client[key])) && isFinite(this.client[key]) ? this.client[key]: this.config[key];
+  this.ttl = !isNaN(parseFloat(this.client[key])) && isFinite(this.client[key]) ? this.client[key]: this.config[key];
 
-  if (ttl !== null) {
+  if (this.ttl !== null) {
     expires = new Date(this.now);
-    expires.setSeconds(expires.getSeconds() + ttl);
+    expires.setSeconds(expires.getSeconds() + this.ttl);
   }
 
   return expires;
@@ -470,8 +470,8 @@ function sendResponse (done) {
     access_token: this.accessToken
   };
 
-  if (this.config.accessTokenLifetime !== null) {
-    response.expires_in = this.config.accessTokenLifetime;
+  if (this.config.accessTokenLifetime !== null || this.ttl !== null) {
+    response.expires_in = this.ttl || this.config.accessTokenLifetime;
   }
 
   if (this.refreshToken) response.refresh_token = this.refreshToken;

--- a/test/authCodeGrant.js
+++ b/test/authCodeGrant.js
@@ -230,6 +230,34 @@ describe('AuthCodeGrant', function() {
       .end();
   });
 
+  it('should try to save auth code with a client-specific timeout', function (done) {
+    var app = bootstrap({
+      getClient: function (clientId, clientSecret, callback) {
+        callback(false, {
+          clientId: 'thom',
+          redirectUri: 'http://nightworld.com',
+          authCodeLifetime: 3600
+        });
+      },
+      saveAuthCode: function (authCode, clientId, expires, user, callback) {
+        should.exist(authCode);
+        authCode.should.have.lengthOf(40);
+        clientId.should.equal('thom');
+        (+expires).should.be.approximately((+new Date()) + (3600 * 1000), 100);
+        done();
+      }
+    }, [false, true]);
+
+    request(app)
+      .post('/authorise')
+      .send({
+        response_type: 'code',
+        client_id: 'thom',
+        redirect_uri: 'http://nightworld.com'
+      })
+      .end();
+  });
+
   it('should accept valid request and return code using POST', function (done) {
     var code;
 

--- a/test/grant.js
+++ b/test/grant.js
@@ -530,7 +530,7 @@ describe('Grant', function() {
           res.body.refresh_token.should.be.instanceOf(String);
           res.body.refresh_token.should.have.length(40);
           res.body.token_type.should.equal('bearer');
-          res.body.expires_in.should.equal(3600);
+          res.body.expires_in.should.equal(1209600);
 
           done();
         });


### PR DESCRIPTION
Adds three attributes to the client entity that determine the grant, access token, or refresh
token lifetime.  If any of the attributes is not present in the client object, the default config
value is used.

* authCodeLifetime
* accessTokenLifetime
* refreshTokenLifetime