### PR TITLE
save/use expose returned clientId if provided

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -144,6 +144,11 @@ function checkClient (done) {
     // Expose validated client
     self.req.oauth = { client: client };
 
+    if (client.clientId) {
+        self.client.clientId = client.clientId;
+    }
+
+
     done();
   });
 }


### PR DESCRIPTION
Hi we love the node-oauth2-server module, but I find myself wanting to use results from the getClient calls elsewhere (like when checking if a grant type is allowed).  In the authCodeGrant module, the client is saved / re-used ( https://github.com/thomseddon/node-oauth2-server/blob/master/lib/authCodeGrant.js#L126 ), but that doesn't seem to be the case in the grant module.  So this seems like the most minimal modification, that still passes the tests, that lets the clientId be modified during a getClient call.  Can we do something like this, thoughts?

Thanks!
David
