### PR TITLE
Change bearer to be case insensitive

### DIFF
--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -72,7 +72,7 @@ function getBearerToken (done) {
 
   // Header: http://tools.ietf.org/html/rfc6750#section-2.1
   if (headerToken) {
-    var matches = headerToken.match(/Bearer\s(\S+)/);
+    var matches = headerToken.match(/Bearer\s(\S+)/i);
 
     if (!matches) {
       return done(error('invalid_request', 'Malformed auth header'));


### PR DESCRIPTION
Some framework support only bearer other Bearer, to be more generic ignore capitalization.