### PR TITLE
Make documentation consistent

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -55,7 +55,7 @@ Note: As no model was actually implemented here, delving any deeper, i.e. passin
 - *string* **model**
  - Model object (see below)
 - *array* **grants**
- - grant types you wish to support, currently the module supports `password` and `refresh_token`
+ - grant types you wish to support, currently the module supports `authorization_code`, `password`, `refresh_token`, `client_credentials` and `extension`
   - Default: `[]`
 - *function|boolean* **debug**
  - If `true` errors will be  logged to console. You may also pass a custom function, in which case that function will be called with the error as its first argument


### PR DESCRIPTION
Super simple fix to the documentation to make the Options section of the readme match the Features section.

Fixes #164 
