### PR TITLE
Adding req.user support to the postgres example

### DIFF
--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -74,7 +74,7 @@ app.post('/login', function (req, res, next) {
 
 app.all('/', app.oauth.authorise(), function (req, res) {
   // Will require a valid access_token
-  res.send({message: 'Secret area', user: req.user});
+  res.send({message: req.user ? 'Secret area, welcome ' + req.user.firstname : 'Secret area', user: req.user});
 });
 
 app.all('/public', function (req, res) {

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -72,12 +72,12 @@ app.post('/login', function (req, res, next) {
   }
 });
 
-app.get('/secret', app.oauth.authorise(), function (req, res) {
+app.all('/', app.oauth.authorise(), function (req, res) {
   // Will require a valid access_token
   res.send({message: 'Secret area', user: req.user});
 });
 
-app.get('/public', function (req, res) {
+app.all('/public', function (req, res) {
   // Does not require an access_token
   res.send({message:'Public area'});
 });

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -74,12 +74,12 @@ app.post('/login', function (req, res, next) {
 
 app.get('/secret', app.oauth.authorise(), function (req, res) {
   // Will require a valid access_token
-  res.send('Secret area');
+  res.send({message: 'Secret area', user: req.user});
 });
 
 app.get('/public', function (req, res) {
   // Does not require an access_token
-  res.send('Public area');
+  res.send({message:'Public area'});
 });
 
 // Error handling

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -19,7 +19,7 @@ app.all('/oauth/token', app.oauth.grant());
 
 // Show them the "do you authorise xyz app to access your content?" page
 app.get('/oauth/authorise', function (req, res, next) {
-  if (!req.session.user) {
+  if (!req.session || !req.session.user) {
     // If they aren't logged in, send them to your own login implementation
     return res.redirect('/login?redirect=' + req.path + '&client_id=' +
         req.query.client_id + '&redirect_uri=' + req.query.redirect_uri);
@@ -86,3 +86,5 @@ app.get('/public', function (req, res) {
 app.use(app.oauth.errorHandler());
 
 app.listen(3000);
+
+exports.app = app;

--- a/examples/postgresql/schema.sql
+++ b/examples/postgresql/schema.sql
@@ -70,7 +70,8 @@ CREATE TABLE oauth_refresh_tokens (
 CREATE TABLE users (
     id uuid NOT NULL,
     username text NOT NULL,
-    password text NOT NULL
+    password text NOT NULL,
+    firstname text
 );
 
 
@@ -116,4 +117,3 @@ CREATE INDEX users_username_password ON users USING btree (username, password);
 --
 -- PostgreSQL database dump complete
 --
-

--- a/examples/postgresql/testData.sql
+++ b/examples/postgresql/testData.sql
@@ -1,0 +1,6 @@
+--
+-- PostgreSQL sample data
+--
+
+INSERT INTO users(id, username, password, firstname) VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'thom', 'nightW0r1d', 'Thom');
+INSERT INTO oauth_access_tokens(access_token, client_id, user_id, expires) VALUES ('JKNW-9382j-JK83h2-ak3aiUIW', 'afancyagregatorapp', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', TIMESTAMP '2019-01-08 04:05:06');


### PR DESCRIPTION
Since version 1.3.0 it looks like `req.user` should be set if you set `token.user` in `getAccessToken`

### 1.3.0 changelog
 - Add passthroughErrors option
 - Optimise oauth.handler() with regex caching
 - Add PostgreSQL example
 - Allow req.user to be set by setting token.user in getAccessToken


This PR 
* found a bug when the `req.session` is `undefined`
* changed the sample routes to return json and welcome the user if they are authorized so you get the idea (instead of calling the route `secret`) 
* adds a method in the models to get out the user details, and make the user available in the token.user 
* like the redis example https://github.com/thomseddon/node-oauth2-server/blob/master/examples/redis/testData.js, provides some sample data creation


