### PR TITLE
Running authorise test on example apps 

### DIFF
--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -74,7 +74,7 @@ app.post('/login', function (req, res, next) {
 
 app.all('/', app.oauth.authorise(), function (req, res) {
   // Will require a valid access_token
-  res.send({message: 'Secret area', user: req.user});
+  res.send({message: req.user ? 'Secret area, welcome ' + req.user.firstname : 'Secret area', user: req.user});
 });
 
 app.all('/public', function (req, res) {

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -72,12 +72,12 @@ app.post('/login', function (req, res, next) {
   }
 });
 
-app.get('/secret', app.oauth.authorise(), function (req, res) {
+app.all('/', app.oauth.authorise(), function (req, res) {
   // Will require a valid access_token
   res.send({message: 'Secret area', user: req.user});
 });
 
-app.get('/public', function (req, res) {
+app.all('/public', function (req, res) {
   // Does not require an access_token
   res.send({message:'Public area'});
 });

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -74,12 +74,12 @@ app.post('/login', function (req, res, next) {
 
 app.get('/secret', app.oauth.authorise(), function (req, res) {
   // Will require a valid access_token
-  res.send('Secret area');
+  res.send({message: 'Secret area', user: req.user});
 });
 
 app.get('/public', function (req, res) {
   // Does not require an access_token
-  res.send('Public area');
+  res.send({message:'Public area'});
 });
 
 // Error handling

--- a/examples/postgresql/index.js
+++ b/examples/postgresql/index.js
@@ -19,7 +19,7 @@ app.all('/oauth/token', app.oauth.grant());
 
 // Show them the "do you authorise xyz app to access your content?" page
 app.get('/oauth/authorise', function (req, res, next) {
-  if (!req.session.user) {
+  if (!req.session || !req.session.user) {
     // If they aren't logged in, send them to your own login implementation
     return res.redirect('/login?redirect=' + req.path + '&client_id=' +
         req.query.client_id + '&redirect_uri=' + req.query.redirect_uri);
@@ -86,3 +86,5 @@ app.get('/public', function (req, res) {
 app.use(app.oauth.errorHandler());
 
 app.listen(3000);
+
+exports.app = app;

--- a/examples/postgresql/schema.sql
+++ b/examples/postgresql/schema.sql
@@ -70,7 +70,8 @@ CREATE TABLE oauth_refresh_tokens (
 CREATE TABLE users (
     id uuid NOT NULL,
     username text NOT NULL,
-    password text NOT NULL
+    password text NOT NULL,
+    firstname text
 );
 
 
@@ -116,4 +117,3 @@ CREATE INDEX users_username_password ON users USING btree (username, password);
 --
 -- PostgreSQL database dump complete
 --
-

--- a/examples/postgresql/schema.sql
+++ b/examples/postgresql/schema.sql
@@ -36,7 +36,7 @@ CREATE TABLE oauth_access_tokens (
     access_token text NOT NULL,
     client_id text NOT NULL,
     user_id uuid NOT NULL,
-    expires timestamp without time zone NOT NULL
+    expires timestamp without time zone
 );
 
 
@@ -59,7 +59,7 @@ CREATE TABLE oauth_refresh_tokens (
     refresh_token text NOT NULL,
     client_id text NOT NULL,
     user_id uuid NOT NULL,
-    expires timestamp without time zone NOT NULL
+    expires timestamp without time zone
 );
 
 

--- a/examples/postgresql/testData.sql
+++ b/examples/postgresql/testData.sql
@@ -4,3 +4,5 @@
 
 INSERT INTO users(id, username, password, firstname) VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'thom', 'nightW0r1d', 'Thom');
 INSERT INTO oauth_access_tokens(access_token, client_id, user_id, expires) VALUES ('JKNW-9382j-JK83h2-ak3aiUIW', 'afancyagregatorapp', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', TIMESTAMP '2019-01-08 04:05:06');
+INSERT INTO oauth_access_tokens(access_token, client_id, user_id, expires) VALUES ('test-9382j-JK83h2-expired', 'afancyagregatorapp', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', TIMESTAMP '2000-01-08 04:05:06');
+INSERT INTO oauth_access_tokens(access_token, client_id, user_id, expires) VALUES ('test-9382j-never-expired', 'afancyagregatorapp', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', null);

--- a/examples/postgresql/testData.sql
+++ b/examples/postgresql/testData.sql
@@ -1,0 +1,6 @@
+--
+-- PostgreSQL sample data
+--
+
+INSERT INTO users(id, username, password, firstname) VALUES ('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', 'thom', 'nightW0r1d', 'Thom');
+INSERT INTO oauth_access_tokens(access_token, client_id, user_id, expires) VALUES ('JKNW-9382j-JK83h2-ak3aiUIW', 'afancyagregatorapp', 'a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11', TIMESTAMP '2019-01-08 04:05:06');

--- a/examples/test/authorise.js
+++ b/examples/test/authorise.js
@@ -1,0 +1,240 @@
+/**
+ * Copyright 2013-present NightWorld.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+var express = require('express'),
+  bodyParser = require('body-parser'),
+  request = require('supertest'),
+  should = require('should');
+
+var oauth2server = require('../');
+
+var bootstrap = function (oauthConfig) {
+  if (oauthConfig === 'mockValid') {
+    oauthConfig = {
+      model: {
+        getAccessToken: function (token, callback) {
+          token.should.equal('thom');
+          var expires = new Date();
+          expires.setSeconds(expires.getSeconds() + 20);
+          callback(false, { expires: expires });
+        }
+      }
+    };
+  }
+
+  var app = express();
+  app.oauth = oauth2server(oauthConfig || { model: {} });
+
+  app.use(bodyParser());
+  app.all('/', app.oauth.authorise());
+
+
+  app.all('/', function (req, res) {
+    res.send('nightworld');
+  });
+
+  app.use(app.oauth.errorHandler());
+
+  return app;
+};
+
+describe('Authorise', function() {
+
+  it('should detect no access token', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .get('/')
+      .expect(400, /the access token was not found/i, done);
+  });
+
+  it('should allow valid token as query param', function (done){
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .get('/?access_token=thom')
+      .expect(200, /nightworld/, done);
+  });
+
+  it('should require application/x-www-form-urlencoded when access token is ' +
+      'in body', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .post('/')
+      .send({ access_token: 'thom' })
+      .expect(400, /content type must be application\/x-www-form-urlencoded/i,
+        done);
+  });
+
+  it('should not allow GET when access token in body', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .get('/')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send({ access_token: 'thom' })
+      .expect(400, /method cannot be GET/i, done);
+  });
+
+  it('should allow valid token in body', function (done){
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .post('/')
+      .set('Content-Type', 'application/x-www-form-urlencoded')
+      .send({ access_token: 'thom' })
+      .expect(200, /nightworld/, done);
+  });
+
+  it('should detect malformed header', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .get('/')
+      .set('Authorization', 'Invalid')
+      .expect(400, /malformed auth header/i, done);
+  });
+
+  it('should allow valid token in header', function (done){
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .get('/')
+      .set('Authorization', 'Bearer thom')
+      .expect(200, /nightworld/, done);
+  });
+
+  it('should allow exactly one method (get: query + auth)', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .get('/?access_token=thom')
+      .set('Authorization', 'Invalid')
+      .expect(400, /only one method may be used/i, done);
+  });
+
+  it('should allow exactly one method (post: query + body)', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .post('/?access_token=thom')
+      .send({
+        access_token: 'thom'
+      })
+      .expect(400, /only one method may be used/i, done);
+  });
+
+  it('should allow exactly one method (post: query + empty body)', function (done) {
+    var app = bootstrap('mockValid');
+
+    request(app)
+      .post('/?access_token=thom')
+      .send({
+        access_token: ''
+      })
+      .expect(400, /only one method may be used/i, done);
+  });
+
+  it('should detect expired token', function (done){
+    var app = bootstrap({
+      model: {
+        getAccessToken: function (token, callback) {
+          callback(false, { expires: 0 }); // Fake expires
+        }
+      }
+    });
+
+    request(app)
+      .get('/?access_token=thom')
+      .expect(401, /the access token provided has expired/i, done);
+  });
+
+  it('should passthrough with valid, non-expiring token (token = null)',
+      function (done) {
+    var app = bootstrap({
+      model: {
+        getAccessToken: function (token, callback) {
+          token.should.equal('thom');
+          callback(false, { expires: null });
+        }
+      }
+    }, false);
+
+    app.get('/', app.oauth.authorise(), function (req, res) {
+      res.send('nightworld');
+    });
+
+    app.use(app.oauth.errorHandler());
+
+    request(app)
+      .get('/?access_token=thom')
+      .expect(200, /nightworld/, done);
+  });
+
+  it('should expose the user id when setting userId', function (done) {
+    var app = bootstrap({
+      model: {
+        getAccessToken: function (token, callback) {
+          var expires = new Date();
+          expires.setSeconds(expires.getSeconds() + 20);
+          callback(false, { expires: expires , userId: 1 });
+        }
+      }
+    }, false);
+
+    app.get('/', app.oauth.authorise(), function (req, res) {
+      req.should.have.property('user');
+      req.user.should.have.property('id');
+      req.user.id.should.equal(1);
+      res.send('nightworld');
+    });
+
+    app.use(app.oauth.errorHandler());
+
+    request(app)
+      .get('/?access_token=thom')
+      .expect(200, /nightworld/, done);
+  });
+
+  it('should expose the user id when setting user object', function (done) {
+    var app = bootstrap({
+      model: {
+        getAccessToken: function (token, callback) {
+          var expires = new Date();
+          expires.setSeconds(expires.getSeconds() + 20);
+          callback(false, { expires: expires , user: { id: 1, name: 'thom' }});
+        }
+      }
+    }, false);
+
+    app.get('/', app.oauth.authorise(), function (req, res) {
+      req.should.have.property('user');
+      req.user.should.have.property('id');
+      req.user.id.should.equal(1);
+      req.user.should.have.property('name');
+      req.user.name.should.equal('thom');
+      res.send('nightworld');
+    });
+
+    app.use(app.oauth.errorHandler());
+
+    request(app)
+      .get('/?access_token=thom')
+      .expect(200, /nightworld/, done);
+  });
+
+});

--- a/examples/test/authorise.js
+++ b/examples/test/authorise.js
@@ -26,20 +26,26 @@ describe('Authorise', function() {
   it('should detect no access token', function (done) {
     request(app)
       .get('/')
-      .expect(400, /the access token was not found/i, done);
+      .expect(400, /The access token was not found/i, done);
+  });
+
+  it('should not allow invalid token as query param', function (done){
+    request(app)
+      .get('/?access_token=JKNW-9382j-JK83h2-notarealtoken')
+      .expect(401, /The access token provided is invalid/, done);
   });
 
   it('should allow valid token as query param', function (done){
     request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
+      .get('/?access_token=JKNW-9382j-JK83h2-ak3aiUIW')
+      .expect(200, /Secret area/, done);
   });
 
   it('should require application/x-www-form-urlencoded when access token is ' +
       'in body', function (done) {
     request(app)
       .post('/')
-      .send({ access_token: 'thom' })
+      .send({ access_token: 'JKNW-9382j-JK83h2-ak3aiUIW' })
       .expect(400, /content type must be application\/x-www-form-urlencoded/i,
         done);
   });
@@ -48,7 +54,7 @@ describe('Authorise', function() {
     request(app)
       .get('/')
       .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({ access_token: 'thom' })
+      .send({ access_token: 'JKNW-9382j-JK83h2-ak3aiUIW' })
       .expect(400, /method cannot be GET/i, done);
   });
 
@@ -56,8 +62,8 @@ describe('Authorise', function() {
     request(app)
       .post('/')
       .set('Content-Type', 'application/x-www-form-urlencoded')
-      .send({ access_token: 'thom' })
-      .expect(200, /nightworld/, done);
+      .send({ access_token: 'JKNW-9382j-JK83h2-ak3aiUIW' })
+      .expect(200, /Secret area/, done);
   });
 
   it('should detect malformed header', function (done) {
@@ -70,29 +76,29 @@ describe('Authorise', function() {
   it('should allow valid token in header', function (done){
     request(app)
       .get('/')
-      .set('Authorization', 'Bearer thom')
-      .expect(200, /nightworld/, done);
+      .set('Authorization', 'Bearer JKNW-9382j-JK83h2-ak3aiUIW')
+      .expect(200, /Secret area/, done);
   });
 
   it('should allow exactly one method (get: query + auth)', function (done) {
     request(app)
-      .get('/?access_token=thom')
+      .get('/?access_token=JKNW-9382j-JK83h2-ak3aiUIW')
       .set('Authorization', 'Invalid')
       .expect(400, /only one method may be used/i, done);
   });
 
   it('should allow exactly one method (post: query + body)', function (done) {
     request(app)
-      .post('/?access_token=thom')
+      .post('/?access_token=JKNW-9382j-JK83h2-ak3aiUIW')
       .send({
-        access_token: 'thom'
+        access_token: 'JKNW-9382j-JK83h2-ak3aiUIW'
       })
       .expect(400, /only one method may be used/i, done);
   });
 
   it('should allow exactly one method (post: query + empty body)', function (done) {
     request(app)
-      .post('/?access_token=thom')
+      .post('/?access_token=JKNW-9382j-JK83h2-ak3aiUIW')
       .send({
         access_token: ''
       })
@@ -101,43 +107,43 @@ describe('Authorise', function() {
 
   it('should detect expired token', function (done){
     request(app)
-      .get('/?access_token=thom')
+      .get('/?access_token=test-9382j-JK83h2-expired')
       .expect(401, /the access token provided has expired/i, done);
   });
 
-  it('should passthrough with valid, non-expiring token (token = null)',
+  it('should passthrough with valid, non-expiring token (token = null)', 
       function (done) {
     request(app)
-      .get('/?access_token=thom')
-      .expect(200, /nightworld/, done);
+      .get('/?access_token=test-9382j-never-expired')
+      .expect(200, /Secret area/, done);
   });
 
   it('should expose the user id when setting userId', function (done) {
     app.get('/mockaroute', app.oauth.authorise(), function (req, res) {
       req.should.have.property('user');
       req.user.should.have.property('id');
-      req.user.id.should.equal(1);
-      res.send('nightworld');
+      req.user.id.should.equal('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+      res.send('Testing if user id is present internally');
     });
 
     request(app)
-      .get('/mockaroute?access_token=thom')
-      .expect(200, /nightworld/, done);
+      .get('/mockaroute?access_token=JKNW-9382j-JK83h2-ak3aiUIW')
+      .expect(200, /Testing if user id is present internally/, done);
   });
 
   it('should expose the user id when setting user object', function (done) {
     app.get('/mockarouteforuserobject', app.oauth.authorise(), function (req, res) {
       req.should.have.property('user');
       req.user.should.have.property('id');
-      req.user.id.should.equal(1);
-      req.user.should.have.property('name');
-      req.user.name.should.equal('thom');
-      res.send('nightworld');
+      req.user.id.should.equal('a0eebc99-9c0b-4ef8-bb6d-6bb9bd380a11');
+      req.user.should.have.property('firstname');
+      req.user.firstname.should.equal('Thom');
+      res.send('Testing if user details are present internally');
     });
 
     request(app)
-      .get('/mockarouteforuserobject?access_token=thom')
-      .expect(200, /nightworld/, done);
+      .get('/mockarouteforuserobject?access_token=JKNW-9382j-JK83h2-ak3aiUIW')
+      .expect(200, /Testing if user details are present internally/, done);
   });
 
 });


### PR DESCRIPTION
As a result, found some things in the postgres example might have been 'bugs' (sent in a separate PR #182 on which this depends)

If you like the idea of adding test for the examples, then 
* I can port some more tests to the examples,
* help make the examples more similar
* My end goal was actually to contribute a couchdb example https://github.com/cesine/node-oauth2-server/tree/feature/couchdb, but I wanted some tests to see if it was working as expected...