### PR TITLE
Updating three error codes to match the OAuth spec.

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -51,6 +51,8 @@ function OAuth2Error (error, description, err) {
       /* falls through */
     case 'invalid_grant':
     case 'invalid_request':
+    case 'unauthorized_client':
+    case 'unsupported_grant_type':
       this.code = 400;
       break;
     case 'invalid_token':

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -217,7 +217,7 @@ function usePasswordGrant (done) {
   var uname = this.req.body.username,
     pword = this.req.body.password;
   if (!uname || !pword) {
-    return done(error('invalid_client',
+    return done(error('invalid_request',
       'Missing parameters. "username" and "password" are required'));
   }
 
@@ -285,7 +285,7 @@ function useClientCredentialsGrant (done) {
     clientSecret = this.client.clientSecret;
 
   if (!clientId || !clientSecret) {
-    return done(error('invalid_client',
+    return done(error('invalid_request',
       'Missing parameters. "client_id" and "client_secret" are required'));
   }
 
@@ -340,7 +340,7 @@ function checkGrantTypeAllowed (done) {
     if (err) return done(error('server_error', false, err));
 
     if (!allowed) {
-      return done(error('invalid_client',
+      return done(error('unauthorized_client',
         'The grant type is unauthorised for this client_id'));
     }
 


### PR DESCRIPTION
The section of the spec that I was comparing to is http://tools.ietf.org/html/rfc6749#section-5.2.

I noticed one difference between the specification and the implementation during testing with missing grant parameters. The other two I noticed while reviewing code. I did not notice any tests in the repository that tested error codes, so I did not make any test updates or additions.

I also added the error codes 'unauthorized_client' and 'unsupported_grant_type' to the OAuth2Error constructor. These two codes should return 400, per the spec.