### PR TITLE
Change error message when missing parameters

### DIFF
--- a/lib/grant.js
+++ b/lib/grant.js
@@ -217,7 +217,7 @@ function usePasswordGrant (done) {
   var uname = this.req.body.username,
     pword = this.req.body.password;
   if (!uname || !pword) {
-    return done(error('invalid_client',
+    return done(error('invalid_request',
       'Missing parameters. "username" and "password" are required'));
   }
 


### PR DESCRIPTION
When `username` and `password`, the error message should be "invalid_request" not "invalid_client". Made debugging very difficult until I found this.