### PR TITLE
Return database clients on failure in PostgreSQL example

### DIFF
--- a/examples/postgresql/model.js
+++ b/examples/postgresql/model.js
@@ -27,7 +27,11 @@ model.getAccessToken = function (bearerToken, callback) {
     if (err) return callback(err);
     client.query('SELECT access_token, client_id, expires, user_id FROM oauth_access_tokens ' +
         'WHERE access_token = $1', [bearerToken], function (err, result) {
-      if (err || !result.rowCount) return callback(err);
+      if (err) return callback(err);
+      if (!result.rowCount) {
+        callback(err);
+        return done();
+      }
       // This object will be exposed in req.oauth.token
       // The user_id field will be exposed in req.user (req.user = { id: "..." }) however if
       // an explicit user object is included (token.user, must include id) it will be exposed
@@ -50,11 +54,18 @@ model.getClient = function (clientId, clientSecret, callback) {
 
     client.query('SELECT client_id, client_secret, redirect_uri FROM oauth_clients WHERE ' +
       'client_id = $1', [clientId], function (err, result) {
-      if (err || !result.rowCount) return callback(err);
+      if (err) return callback(err);
+      if (!result.rowCount) {
+        callback();
+        return done();
+      }
 
       var client = result.rows[0];
 
-      if (clientSecret !== null && client.client_secret !== clientSecret) return callback();
+      if (clientSecret !== null && client.client_secret !== clientSecret) {
+        callback();
+        return done();
+      }
 
       // This object will be exposed in req.oauth.client
       callback(null, {


### PR DESCRIPTION
This small PR adds PostgreSQL client `done()` calls to a few code branches where the database query was successful, to ensure database clients are efficiently returned to the pool.