### PR TITLE
Support custom OAuth2Error in Model object callbacks

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+### 2.4.2
+
+- Support custom `OAuth2Error` in Model object callbacks
+
 ### 2.4.1
 
 - Fix header setting syntax

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -135,7 +135,8 @@ function checkClient (done) {
   var self = this;
   this.model.getClient(this.client.clientId, this.client.clientSecret,
       function (err, client) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
 
     if (!client) {
       return done(error('invalid_client', 'Client credentials are invalid'));
@@ -189,7 +190,8 @@ function useAuthCodeGrant (done) {
 
   var self = this;
   this.model.getAuthCode(code, function (err, authCode) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
 
     if (!authCode || authCode.clientId !== self.client.clientId) {
       return done(error('invalid_grant', 'Invalid code'));
@@ -223,7 +225,8 @@ function usePasswordGrant (done) {
 
   var self = this;
   return this.model.getUser(uname, pword, function (err, user) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
     if (!user) {
       return done(error('invalid_grant', 'User credentials are invalid'));
     }
@@ -247,7 +250,8 @@ function useRefreshTokenGrant (done) {
 
   var self = this;
   this.model.getRefreshToken(token, function (err, refreshToken) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
 
     if (!refreshToken || refreshToken.clientId !== self.client.clientId) {
       return done(error('invalid_grant', 'Invalid refresh token'));
@@ -265,7 +269,8 @@ function useRefreshTokenGrant (done) {
 
     if (self.model.revokeRefreshToken) {
       return self.model.revokeRefreshToken(token, function (err) {
-        if (err) return done(error('server_error', false, err));
+        if (err instanceof error) return done(err);
+        else if (err) return done(error('server_error', false, err));
         done();
       });
     }
@@ -292,7 +297,8 @@ function useClientCredentialsGrant (done) {
   var self = this;
   return this.model.getUserFromClient(clientId, clientSecret,
       function (err, user) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
     if (!user) {
       return done(error('invalid_grant', 'Client credentials are invalid'));
     }
@@ -311,7 +317,8 @@ function useExtendedGrant (done) {
   var self = this;
   this.model.extendedGrant(this.grantType, this.req,
       function (err, supported, user) {
-    if (err) {
+    if (err instanceof error) return done(err);
+    else if (err) {
       return done(error(err.error || 'server_error',
         err.description || err.message, err));
     }
@@ -337,7 +344,8 @@ function useExtendedGrant (done) {
 function checkGrantTypeAllowed (done) {
   this.model.grantTypeAllowed(this.client.clientId, this.grantType,
       function (err, allowed) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
 
     if (!allowed) {
       return done(error('invalid_client',
@@ -397,7 +405,8 @@ function saveAccessToken (done) {
 
   this.model.saveAccessToken(accessToken, this.client.clientId, expires,
       this.user, function (err) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
     done();
   });
 }
@@ -443,7 +452,8 @@ function saveRefreshToken (done) {
 
   this.model.saveRefreshToken(refreshToken, this.client.clientId, expires,
       this.user, function (err) {
-    if (err) return done(error('server_error', false, err));
+    if (err instanceof error) return done(err);
+    else if (err) return done(error('server_error', false, err));
     done();
   });
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "oauth2-server",
   "description": "Complete, compliant and well tested module for implementing an OAuth2 Server/Provider with express in node.js",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "keywords": [
     "oauth",
     "oauth2"


### PR DESCRIPTION
Allow Model object callbacks to handle a custom `OAuth2Error` object instead of directly force to `500 server_error` for each error.
This will allow custom responses and should fix issues referenced in #115.

```
var OAuth2Error = require('oauth2-server/lib/error');

model.getUser = function (username, password, callback) {
    var user = doSomething(username, password);

    // user found
    callback(null, user)

    // user not found
    callback()

    // custom error message
    callback(new OAuth2Error('invalid_grant', 'Credentials not valid. Try again.'))

    // custom error message with status code
    var err = new OAuth2Error('unconfirmed_email', 'You need to confirm your email address before login')
    err.code = 400;
    callback(err);
}
```