### PR TITLE
Changed Koa wrapper link to project wrapping v3

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Complete, compliant and well tested module for implementing an OAuth2 server in 
 
 # Quick Start
 
-  The _node-oauth2-server_ module is framework-agnostic but there are several wrappers available for popular frameworks such as [express](https://github.com/seegno/express-oauth-server) and [koa](https://github.com/thomseddon/koa-oauth-server).
+  The _node-oauth2-server_ module is framework-agnostic but there are several wrappers available for popular frameworks such as [express](https://github.com/seegno/express-oauth-server) and [koa 2](https://github.com/ubilogix/koa-oauth-server).
 
   Using the _express_ wrapper (_recommended_):
 


### PR DESCRIPTION
This wrapper for Koa 2 fully supports the new oauth2-server library, and provides a fully functional reference implementation for four grant flows (password, authorization code, refresh token, client credentials).

Note: One small issue remains, namely bumping the required version of the oauth2-server module, which is not yet up-to-date with the latest on npmjs.
