### PR TITLE
Conditionally promisify all model functions

### DIFF
--- a/lib/grant-types/abstract-grant-type.js
+++ b/lib/grant-types/abstract-grant-type.js
@@ -7,7 +7,7 @@
 var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidScopeError = require('../errors/invalid-scope-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var is = require('../validator/is');
 var tokenUtil = require('../utils/token-util');
 
@@ -37,7 +37,7 @@ function AbstractGrantType(options) {
 
 AbstractGrantType.prototype.generateAccessToken = function() {
   if (this.model.generateAccessToken) {
-    return Promise.try(promisify(this.model.generateAccessToken));
+    return promisify(this.model.generateAccessToken)();
   }
 
   return tokenUtil.generateRandomToken();
@@ -49,7 +49,7 @@ AbstractGrantType.prototype.generateAccessToken = function() {
 
 AbstractGrantType.prototype.generateRefreshToken = function() {
   if (this.model.generateRefreshToken) {
-    return Promise.try(promisify(this.model.generateRefreshToken));
+    return promisify(this.model.generateRefreshToken)();
   }
 
   return tokenUtil.generateRandomToken();
@@ -96,7 +96,7 @@ AbstractGrantType.prototype.getScope = function(request) {
  */
 AbstractGrantType.prototype.validateScope = function(user, client, scope) {
   if (this.model.validateScope) {
-    return Promise.try(promisify(this.model.validateScope, 3), [user, client, scope])
+    return promisify(this.model.validateScope, 3)(user, client, scope)
       .then(function (scope) {
         if (!scope) {
           throw new InvalidScopeError('Invalid scope: Requested scope is invalid');
@@ -104,6 +104,8 @@ AbstractGrantType.prototype.validateScope = function(user, client, scope) {
 
         return scope;
       });
+  } else {
+    return scope;
   }
 };
 

--- a/lib/grant-types/abstract-grant-type.js
+++ b/lib/grant-types/abstract-grant-type.js
@@ -7,6 +7,7 @@
 var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidScopeError = require('../errors/invalid-scope-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var is = require('../validator/is');
 var tokenUtil = require('../utils/token-util');
 
@@ -36,7 +37,7 @@ function AbstractGrantType(options) {
 
 AbstractGrantType.prototype.generateAccessToken = function() {
   if (this.model.generateAccessToken) {
-    return Promise.try(this.model.generateAccessToken);
+    return Promise.try(promisify(this.model.generateAccessToken));
   }
 
   return tokenUtil.generateRandomToken();
@@ -48,7 +49,7 @@ AbstractGrantType.prototype.generateAccessToken = function() {
 
 AbstractGrantType.prototype.generateRefreshToken = function() {
   if (this.model.generateRefreshToken) {
-    return Promise.try(this.model.generateRefreshToken);
+    return Promise.try(promisify(this.model.generateRefreshToken));
   }
 
   return tokenUtil.generateRandomToken();
@@ -94,14 +95,16 @@ AbstractGrantType.prototype.getScope = function(request) {
  * Validate requested scope.
  */
 AbstractGrantType.prototype.validateScope = function(user, client, scope) {
-  return Promise.try(this.model.validateScope, [user, client, scope])
-    .then(function(scope) {
-      if(!scope) {
-        throw new InvalidScopeError('Invalid scope: Requested scope is invalid');
-      }
+  if (this.model.validateScope) {
+    return Promise.try(promisify(this.model.validateScope, 3), [user, client, scope])
+      .then(function (scope) {
+        if (!scope) {
+          throw new InvalidScopeError('Invalid scope: Requested scope is invalid');
+        }
 
-      return scope;
-    });
+        return scope;
+      });
+  }
 };
 
 /**

--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -9,6 +9,7 @@ var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var ServerError = require('../errors/server-error');
 var is = require('../validator/is');
 var util = require('util');
@@ -87,8 +88,7 @@ AuthorizationCodeGrantType.prototype.getAuthorizationCode = function(request, cl
   if (!is.vschar(request.body.code)) {
     throw new InvalidRequestError('Invalid parameter: `code`');
   }
-
-  return Promise.try(this.model.getAuthorizationCode, request.body.code)
+  return Promise.try(promisify(this.model.getAuthorizationCode, 1), request.body.code)
     .then(function(code) {
       if (!code) {
         throw new InvalidGrantError('Invalid grant: authorization code is invalid');
@@ -160,7 +160,7 @@ AuthorizationCodeGrantType.prototype.getAuthorizationCode = function(request, cl
  */
 
 AuthorizationCodeGrantType.prototype.revokeAuthorizationCode = function(code) {
-  return Promise.try(this.model.revokeAuthorizationCode, code)
+  return Promise.try(promisify(this.model.revokeAuthorizationCode, 1), code)
     .then(function(status) {
       if (!status) {
         throw new InvalidGrantError('Invalid grant: authorization code is invalid');
@@ -191,8 +191,15 @@ AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authoriz
         scope: scope
       };
 
-      return this.model.saveToken(token, client, user);
+      return token;
+    })
+    .then(function(token) {
+      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
+        .then(function(savedToken) {
+          return savedToken;
+        });
     });
+
 };
 
 /**

--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -9,7 +9,7 @@ var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var ServerError = require('../errors/server-error');
 var is = require('../validator/is');
 var util = require('util');
@@ -88,7 +88,7 @@ AuthorizationCodeGrantType.prototype.getAuthorizationCode = function(request, cl
   if (!is.vschar(request.body.code)) {
     throw new InvalidRequestError('Invalid parameter: `code`');
   }
-  return Promise.try(promisify(this.model.getAuthorizationCode, 1), request.body.code)
+  return promisify(this.model.getAuthorizationCode, 1)(request.body.code)
     .then(function(code) {
       if (!code) {
         throw new InvalidGrantError('Invalid grant: authorization code is invalid');
@@ -160,7 +160,7 @@ AuthorizationCodeGrantType.prototype.getAuthorizationCode = function(request, cl
  */
 
 AuthorizationCodeGrantType.prototype.revokeAuthorizationCode = function(code) {
-  return Promise.try(promisify(this.model.revokeAuthorizationCode, 1), code)
+  return promisify(this.model.revokeAuthorizationCode, 1)(code)
     .then(function(status) {
       if (!status) {
         throw new InvalidGrantError('Invalid grant: authorization code is invalid');
@@ -191,15 +191,8 @@ AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authoriz
         scope: scope
       };
 
-      return token;
-    })
-    .then(function(token) {
-      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
-        .then(function(savedToken) {
-          return savedToken;
-        });
+      return promisify(this.model.saveToken, 3)(token, client, user);
     });
-
 };
 
 /**

--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -8,7 +8,7 @@ var AbstractGrantType = require('./abstract-grant-type');
 var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var util = require('util');
 
 /**
@@ -70,7 +70,7 @@ ClientCredentialsGrantType.prototype.handle = function(request, client) {
  */
 
 ClientCredentialsGrantType.prototype.getUserFromClient = function(client) {
-  return Promise.try(promisify(this.model.getUserFromClient, 1), client)
+  return promisify(this.model.getUserFromClient, 1)(client)
     .then(function(user) {
       if (!user) {
         throw new InvalidGrantError('Invalid grant: user credentials are invalid');
@@ -100,13 +100,7 @@ ClientCredentialsGrantType.prototype.saveToken = function(user, client, scope) {
         scope: scope
       };
 
-      return token;
-    })
-    .then(function(token) {
-      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
-        .then(function(savedToken) {
-          return savedToken;
-        });
+      return promisify(this.model.saveToken, 3)(token, client, user);
     });
 };
 

--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -8,6 +8,7 @@ var AbstractGrantType = require('./abstract-grant-type');
 var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var util = require('util');
 
 /**
@@ -69,7 +70,7 @@ ClientCredentialsGrantType.prototype.handle = function(request, client) {
  */
 
 ClientCredentialsGrantType.prototype.getUserFromClient = function(client) {
-  return Promise.try(this.model.getUserFromClient, client)
+  return Promise.try(promisify(this.model.getUserFromClient, 1), client)
     .then(function(user) {
       if (!user) {
         throw new InvalidGrantError('Invalid grant: user credentials are invalid');
@@ -99,7 +100,13 @@ ClientCredentialsGrantType.prototype.saveToken = function(user, client, scope) {
         scope: scope
       };
 
-      return this.model.saveToken(token, client, user);
+      return token;
+    })
+    .then(function(token) {
+      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
+        .then(function(savedToken) {
+          return savedToken;
+        });
     });
 };
 

--- a/lib/grant-types/password-grant-type.js
+++ b/lib/grant-types/password-grant-type.js
@@ -9,6 +9,7 @@ var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var is = require('../validator/is');
 var util = require('util');
 
@@ -87,7 +88,7 @@ PasswordGrantType.prototype.getUser = function(request) {
     throw new InvalidRequestError('Invalid parameter: `password`');
   }
 
-  return Promise.try(this.model.getUser, [request.body.username, request.body.password])
+  return Promise.try(promisify(this.model.getUser, 2), [request.body.username, request.body.password])
     .then(function(user) {
       if (!user) {
         throw new InvalidGrantError('Invalid grant: user credentials are invalid');
@@ -121,7 +122,13 @@ PasswordGrantType.prototype.saveToken = function(user, client, scope) {
         scope: scope
       };
 
-      return this.model.saveToken(token, client, user);
+      return token;
+    })
+    .then(function(token) {
+      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
+        .then(function(savedToken) {
+          return savedToken;
+        });
     });
 };
 

--- a/lib/grant-types/password-grant-type.js
+++ b/lib/grant-types/password-grant-type.js
@@ -9,7 +9,7 @@ var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var is = require('../validator/is');
 var util = require('util');
 
@@ -88,7 +88,7 @@ PasswordGrantType.prototype.getUser = function(request) {
     throw new InvalidRequestError('Invalid parameter: `password`');
   }
 
-  return Promise.try(promisify(this.model.getUser, 2), [request.body.username, request.body.password])
+  return promisify(this.model.getUser, 2)(request.body.username, request.body.password)
     .then(function(user) {
       if (!user) {
         throw new InvalidGrantError('Invalid grant: user credentials are invalid');
@@ -122,13 +122,7 @@ PasswordGrantType.prototype.saveToken = function(user, client, scope) {
         scope: scope
       };
 
-      return token;
-    })
-    .then(function(token) {
-      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
-        .then(function(savedToken) {
-          return savedToken;
-        });
+      return promisify(this.model.saveToken, 3)(token, client, user);
     });
 };
 

--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -9,6 +9,7 @@ var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var ServerError = require('../errors/server-error');
 var is = require('../validator/is');
 var util = require('util');
@@ -85,7 +86,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
     throw new InvalidRequestError('Invalid parameter: `refresh_token`');
   }
 
-  return Promise.try(this.model.getRefreshToken, request.body.refresh_token)
+  return Promise.try(promisify(this.model.getRefreshToken, 1), request.body.refresh_token)
     .then(function(token) {
       if (!token) {
         throw new InvalidGrantError('Invalid grant: refresh token is invalid');
@@ -122,7 +123,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
  */
 
 RefreshTokenGrantType.prototype.revokeToken = function(token) {
-  return Promise.try(this.model.revokeToken, token)
+  return Promise.try(promisify(this.model.revokeToken, 1), token)
     .then(function(status) {
       if (!status) {
         throw new InvalidGrantError('Invalid grant: refresh token is invalid');
@@ -155,7 +156,13 @@ RefreshTokenGrantType.prototype.saveToken = function(user, client, scope) {
         scope: scope
       };
 
-      return this.model.saveToken(token, client, user);
+      return token;
+    })
+    .then(function(token) {
+      return Promise.try(promisify(this.model.saveToken, 3), [token, client, user])
+        .then(function(savedToken) {
+          return savedToken;
+        });
     });
 };
 

--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -9,7 +9,7 @@ var InvalidArgumentError = require('../errors/invalid-argument-error');
 var InvalidGrantError = require('../errors/invalid-grant-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var ServerError = require('../errors/server-error');
 var is = require('../validator/is');
 var util = require('util');
@@ -86,7 +86,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
     throw new InvalidRequestError('Invalid parameter: `refresh_token`');
   }
 
-  return Promise.try(promisify(this.model.getRefreshToken, 1), request.body.refresh_token)
+  return promisify(this.model.getRefreshToken, 1)(request.body.refresh_token)
     .then(function(token) {
       if (!token) {
         throw new InvalidGrantError('Invalid grant: refresh token is invalid');
@@ -123,7 +123,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
  */
 
 RefreshTokenGrantType.prototype.revokeToken = function(token) {
-  return Promise.try(promisify(this.model.revokeToken, 1), token)
+  return promisify(this.model.revokeToken, 1)(token)
     .then(function(status) {
       if (!status) {
         throw new InvalidGrantError('Invalid grant: refresh token is invalid');

--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -10,6 +10,7 @@ var InvalidScopeError = require('../errors/invalid-scope-error');
 var InvalidTokenError = require('../errors/invalid-token-error');
 var OAuthError = require('../errors/oauth-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var Request = require('../request');
 var Response = require('../response');
 var ServerError = require('../errors/server-error');
@@ -196,7 +197,7 @@ AuthenticateHandler.prototype.getTokenFromRequestBody = function(request) {
  */
 
 AuthenticateHandler.prototype.getAccessToken = function(token) {
-  return Promise.try(this.model.getAccessToken, token)
+  return Promise.try(promisify(this.model.getAccessToken, 1), token)
     .then(function(accessToken) {
       if (!accessToken) {
         throw new InvalidTokenError('Invalid token: access token is invalid');
@@ -231,7 +232,7 @@ AuthenticateHandler.prototype.validateAccessToken = function(accessToken) {
  */
 
 AuthenticateHandler.prototype.verifyScope = function(accessToken) {
-  return Promise.try(this.model.verifyScope, [accessToken, this.scope]).then(function(scope) {
+  return Promise.try(promisify(this.model.verifyScope, 2), [accessToken, this.scope]).then(function(scope) {
     if (!scope) {
       throw new InvalidScopeError('Invalid scope: scope is invalid');
     }

--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -10,7 +10,7 @@ var InvalidScopeError = require('../errors/invalid-scope-error');
 var InvalidTokenError = require('../errors/invalid-token-error');
 var OAuthError = require('../errors/oauth-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var Request = require('../request');
 var Response = require('../response');
 var ServerError = require('../errors/server-error');
@@ -197,7 +197,7 @@ AuthenticateHandler.prototype.getTokenFromRequestBody = function(request) {
  */
 
 AuthenticateHandler.prototype.getAccessToken = function(token) {
-  return Promise.try(promisify(this.model.getAccessToken, 1), token)
+  return promisify(this.model.getAccessToken, 1)(token)
     .then(function(accessToken) {
       if (!accessToken) {
         throw new InvalidTokenError('Invalid token: access token is invalid');
@@ -232,7 +232,7 @@ AuthenticateHandler.prototype.validateAccessToken = function(accessToken) {
  */
 
 AuthenticateHandler.prototype.verifyScope = function(accessToken) {
-  return Promise.try(promisify(this.model.verifyScope, 2), [accessToken, this.scope]).then(function(scope) {
+  return promisify(this.model.verifyScope, 2)(accessToken, this.scope).then(function(scope) {
     if (!scope) {
       throw new InvalidScopeError('Invalid scope: scope is invalid');
     }

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -13,6 +13,7 @@ var InvalidRequestError = require('../errors/invalid-request-error');
 var InvalidScopeError = require('../errors/invalid-scope-error');
 var OAuthError = require('../errors/oauth-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var Request = require('../request');
 var Response = require('../response');
 var ServerError = require('../errors/server-error');
@@ -113,7 +114,6 @@ AuthorizeHandler.prototype.handle = function(request, response) {
           if (!(e instanceof OAuthError)) {
             e = new ServerError(e);
           }
-
           var redirectUri = this.buildErrorRedirectUri(uri, e);
 
           this.updateResponse(response, redirectUri, state);
@@ -129,9 +129,8 @@ AuthorizeHandler.prototype.handle = function(request, response) {
 
 AuthorizeHandler.prototype.generateAuthorizationCode = function() {
   if (this.model.generateAuthorizationCode) {
-    return Promise.try(this.model.generateAuthorizationCode);
+    return Promise.try(promisify(this.model.generateAuthorizationCode));
   }
-
   return tokenUtil.generateRandomToken();
 };
 
@@ -143,7 +142,6 @@ AuthorizeHandler.prototype.getAuthorizationCodeLifetime = function() {
   var expires = new Date();
 
   expires.setSeconds(expires.getSeconds() + this.authorizationCodeLifetime);
-
   return expires;
 };
 
@@ -167,8 +165,7 @@ AuthorizeHandler.prototype.getClient = function(request) {
   if (redirectUri && !is.uri(redirectUri)) {
     throw new InvalidRequestError('Invalid request: `redirect_uri` is not a valid URI');
   }
-
-  return Promise.try(this.model.getClient, clientId)
+  return Promise.try(promisify(this.model.getClient, 1), clientId)
     .then(function(client) {
       if (!client) {
         throw new InvalidClientError('Invalid client: client credentials are invalid');
@@ -189,7 +186,6 @@ AuthorizeHandler.prototype.getClient = function(request) {
       if (redirectUri && !_.contains(client.redirectUris, redirectUri)) {
         throw new InvalidClientError('Invalid client: `redirect_uri` does not match client value');
       }
-
       return client;
     });
 };
@@ -234,8 +230,7 @@ AuthorizeHandler.prototype.getUser = function(request, response) {
   if (this.authenticateHandler instanceof AuthenticateHandler) {
     return this.authenticateHandler.handle(request, response).get('user');
   }
-
-  return Promise.try(this.authenticateHandler.handle, [request, response]).then(function(user) {
+  return Promise.try(promisify(this.authenticateHandler.handle, 2), [request, response]).then(function(user) {
     if (!user) {
       throw new ServerError('Server error: `handle()` did not return a `user` object');
     }
@@ -263,8 +258,7 @@ AuthorizeHandler.prototype.saveAuthorizationCode = function(authorizationCode, e
     redirectUri: redirectUri,
     scope: scope
   };
-
-  return Promise.try(this.model.saveAuthorizationCode, [code, client, user]);
+  return Promise.try(promisify(this.model.saveAuthorizationCode, 3), [code, client, user]);
 };
 
 /**

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -13,7 +13,7 @@ var InvalidRequestError = require('../errors/invalid-request-error');
 var InvalidScopeError = require('../errors/invalid-scope-error');
 var OAuthError = require('../errors/oauth-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var Request = require('../request');
 var Response = require('../response');
 var ServerError = require('../errors/server-error');
@@ -129,7 +129,7 @@ AuthorizeHandler.prototype.handle = function(request, response) {
 
 AuthorizeHandler.prototype.generateAuthorizationCode = function() {
   if (this.model.generateAuthorizationCode) {
-    return Promise.try(promisify(this.model.generateAuthorizationCode));
+    return promisify(this.model.generateAuthorizationCode)();
   }
   return tokenUtil.generateRandomToken();
 };
@@ -165,7 +165,7 @@ AuthorizeHandler.prototype.getClient = function(request) {
   if (redirectUri && !is.uri(redirectUri)) {
     throw new InvalidRequestError('Invalid request: `redirect_uri` is not a valid URI');
   }
-  return Promise.try(promisify(this.model.getClient, 1), clientId)
+  return promisify(this.model.getClient, 2)(clientId, null)
     .then(function(client) {
       if (!client) {
         throw new InvalidClientError('Invalid client: client credentials are invalid');
@@ -230,7 +230,7 @@ AuthorizeHandler.prototype.getUser = function(request, response) {
   if (this.authenticateHandler instanceof AuthenticateHandler) {
     return this.authenticateHandler.handle(request, response).get('user');
   }
-  return Promise.try(promisify(this.authenticateHandler.handle, 2), [request, response]).then(function(user) {
+  return promisify(this.authenticateHandler.handle, 2)(request, response).then(function(user) {
     if (!user) {
       throw new ServerError('Server error: `handle()` did not return a `user` object');
     }
@@ -258,7 +258,7 @@ AuthorizeHandler.prototype.saveAuthorizationCode = function(authorizationCode, e
     redirectUri: redirectUri,
     scope: scope
   };
-  return Promise.try(promisify(this.model.saveAuthorizationCode, 3), [code, client, user]);
+  return promisify(this.model.saveAuthorizationCode, 3)(code, client, user);
 };
 
 /**

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -127,10 +127,9 @@ TokenHandler.prototype.getClient = function(request, response) {
   if (!is.vschar(credentials.clientSecret)) {
     throw new InvalidRequestError('Invalid parameter: `client_secret`');
   }
-  console.log(this.model.getClient);
+
   return Promise.try(promisify(this.model.getClient, 2), [credentials.clientId, credentials.clientSecret])
     .then(function(client) {
-      console.log('here');
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');
       }

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -11,6 +11,7 @@ var InvalidClientError = require('../errors/invalid-client-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var OAuthError = require('../errors/oauth-error');
 var Promise = require('bluebird');
+var promisify = require('promisify-any');
 var Request = require('../request');
 var Response = require('../response');
 var ServerError = require('../errors/server-error');
@@ -126,9 +127,10 @@ TokenHandler.prototype.getClient = function(request, response) {
   if (!is.vschar(credentials.clientSecret)) {
     throw new InvalidRequestError('Invalid parameter: `client_secret`');
   }
-
-  return Promise.try(this.model.getClient, [credentials.clientId, credentials.clientSecret])
+  console.log(this.model.getClient);
+  return Promise.try(promisify(this.model.getClient, 2), [credentials.clientId, credentials.clientSecret])
     .then(function(client) {
+      console.log('here');
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');
       }

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -11,7 +11,7 @@ var InvalidClientError = require('../errors/invalid-client-error');
 var InvalidRequestError = require('../errors/invalid-request-error');
 var OAuthError = require('../errors/oauth-error');
 var Promise = require('bluebird');
-var promisify = require('promisify-any');
+var promisify = require('promisify-any').use(Promise);
 var Request = require('../request');
 var Response = require('../response');
 var ServerError = require('../errors/server-error');
@@ -128,7 +128,7 @@ TokenHandler.prototype.getClient = function(request, response) {
     throw new InvalidRequestError('Invalid parameter: `client_secret`');
   }
 
-  return Promise.try(promisify(this.model.getClient, 2), [credentials.clientId, credentials.clientSecret])
+  return promisify(this.model.getClient, 2)(credentials.clientId, credentials.clientSecret)
     .then(function(client) {
       if (!client) {
         throw new InvalidClientError('Invalid client: client is invalid');

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "bluebird": "^2.9.13",
     "camel-case": "^1.1.1",
     "lodash": "^3.3.1",
+    "promisify-any": "2.0.1",
     "standard-http-error": "^1.1.0",
     "type-is": "^1.6.0",
     "validator.js": "^1.1.1"

--- a/test/integration/grant-types/authorization-code-grant-type_test.js
+++ b/test/integration/grant-types/authorization-code-grant-type_test.js
@@ -154,6 +154,19 @@ describe('AuthorizationCodeGrantType integration', function() {
 
       grantType.handle(request, client).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var client = { id: 'foobar' };
+      var model = {
+        getAuthorizationCode: function(code, callback) { callback(null, { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() * 2), user: {} }); },
+        revokeAuthorizationCode: function(code, callback) { callback(null, { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() / 2), user: {} }); },
+        saveToken: function(tokenToSave, client, user, callback) { callback(null, tokenToSave); }
+      };
+      var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+      var request = new Request({ body: { code: 12345 }, headers: {}, method: {}, query: {} });
+
+      grantType.handle(request, client).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('getAuthorizationCode()', function() {
@@ -374,6 +387,20 @@ describe('AuthorizationCodeGrantType integration', function() {
 
       grantType.getAuthorizationCode(request, client).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var authorizationCode = { authorizationCode: 12345, client: { id: 'foobar' }, expiresAt: new Date(new Date() * 2), user: {} };
+      var client = { id: 'foobar' };
+      var model = {
+        getAuthorizationCode: function(code, callback) { callback(null, authorizationCode); },
+        revokeAuthorizationCode: function() {},
+        saveToken: function() {}
+      };
+      var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+      var request = new Request({ body: { code: 12345 }, headers: {}, method: {}, query: {} });
+
+      grantType.getAuthorizationCode(request, client).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('validateRedirectUri()', function() {
@@ -458,6 +485,18 @@ describe('AuthorizationCodeGrantType integration', function() {
 
       grantType.revokeAuthorizationCode(authorizationCode).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var authorizationCode = { authorizationCode: 12345, client: {}, expiresAt: new Date(new Date() / 2), user: {} };
+      var model = {
+        getAuthorizationCode: function() {},
+        revokeAuthorizationCode: function(code, callback) { callback(null, authorizationCode); },
+        saveToken: function() {}
+      };
+      var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.revokeAuthorizationCode(authorizationCode).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('saveToken()', function() {
@@ -496,6 +535,18 @@ describe('AuthorizationCodeGrantType integration', function() {
         getAuthorizationCode: function() {},
         revokeAuthorizationCode: function() {},
         saveToken: function() { return token; }
+      };
+      var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.saveToken(token).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support callbacks', function() {
+      var token = {};
+      var model = {
+        getAuthorizationCode: function() {},
+        revokeAuthorizationCode: function() {},
+        saveToken: function(tokenToSave, client, user, callback) { callback(null, token); }
       };
       var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/grant-types/client-credentials-grant-type_test.js
+++ b/test/integration/grant-types/client-credentials-grant-type_test.js
@@ -189,6 +189,18 @@ describe('ClientCredentialsGrantType integration', function() {
 
       grantType.getUserFromClient(request, {}).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var user = { email: 'foo@bar.com' };
+      var model = {
+        getUserFromClient: function(userId, callback) { callback(null, user); },
+        saveToken: function() {}
+      };
+      var grantType = new ClientCredentialsGrantType({ accessTokenLifetime: 120, model: model });
+      var request = new Request({ body: {}, headers: {}, method: {}, query: {} });
+
+      grantType.getUserFromClient(request, {}).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('saveToken()', function() {
@@ -224,6 +236,17 @@ describe('ClientCredentialsGrantType integration', function() {
       var model = {
         getUserFromClient: function() {},
         saveToken: function() { return token; }
+      };
+      var grantType = new ClientCredentialsGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.saveToken(token).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support callbacks', function() {
+      var token = {};
+      var model = {
+        getUserFromClient: function() {},
+        saveToken: function(tokenToSave, client, user, callback) { callback(null, token); }
       };
       var grantType = new ClientCredentialsGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/grant-types/password-grant-type_test.js
+++ b/test/integration/grant-types/password-grant-type_test.js
@@ -134,6 +134,19 @@ describe('PasswordGrantType integration', function() {
 
       grantType.handle(request, client).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var client = { id: 'foobar' };
+      var token = {};
+      var model = {
+        getUser: function(username, password, callback) { callback(null, {}); },
+        saveToken: function(tokenToSave, client, user, callback) { callback(null, token); }
+      };
+      var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
+      var request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
+
+      grantType.handle(request, client).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('getUser()', function() {
@@ -264,6 +277,18 @@ describe('PasswordGrantType integration', function() {
 
       grantType.getUser(request).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var user = { email: 'foo@bar.com' };
+      var model = {
+        getUser: function(username, password, callback) { callback(null, user); },
+        saveToken: function() {}
+      };
+      var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
+      var request = new Request({ body: { username: 'foo', password: 'bar' }, headers: {}, method: {}, query: {} });
+
+      grantType.getUser(request).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('saveToken()', function() {
@@ -299,6 +324,17 @@ describe('PasswordGrantType integration', function() {
       var model = {
         getUser: function() {},
         saveToken: function() { return token; }
+      };
+      var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.saveToken(token).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support callbacks', function() {
+      var token = {};
+      var model = {
+        getUser: function() {},
+        saveToken: function(tokenToSave, client, user, callback) { callback(null, token); }
       };
       var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/grant-types/refresh-token-grant-type_test.js
+++ b/test/integration/grant-types/refresh-token-grant-type_test.js
@@ -154,6 +154,19 @@ describe('RefreshTokenGrantType integration', function() {
 
       grantType.handle(request, client).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var client = { id: 123 };
+      var model = {
+        getRefreshToken: function(refreshToken, callback) { callback(null, { accessToken: 'foo', client: { id: 123 }, user: {} }); },
+        revokeToken: function(refreshToken, callback) { callback(null, { accessToken: 'foo', client: {}, refreshTokenExpiresAt: new Date(new Date() / 2), user: {} }); },
+        saveToken: function(tokenToSave, client, user, callback) { callback(null,{ accessToken: 'foo', client: {}, user: {} }); }
+      };
+      var grantType = new RefreshTokenGrantType({ accessTokenLifetime: 123, model: model });
+      var request = new Request({ body: { refresh_token: 'foobar' }, headers: {}, method: {}, query: {} });
+
+      grantType.handle(request, client).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('getRefreshToken()', function() {
@@ -403,6 +416,20 @@ describe('RefreshTokenGrantType integration', function() {
 
       grantType.getRefreshToken(request, client).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var client = { id: 123 };
+      var token = { accessToken: 'foo', client: { id: 123 }, user: {} };
+      var model = {
+        getRefreshToken: function(refreshToken, callback) { callback(null, token); },
+        revokeToken: function() {},
+        saveToken: function() {}
+      };
+      var grantType = new RefreshTokenGrantType({ accessTokenLifetime: 123, model: model });
+      var request = new Request({ body: { refresh_token: 'foobar' }, headers: {}, method: {}, query: {} });
+
+      grantType.getRefreshToken(request, client).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('revokeToken()', function() {
@@ -493,6 +520,18 @@ describe('RefreshTokenGrantType integration', function() {
 
       grantType.revokeToken(token).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var token = { accessToken: 'foo', client: {}, refreshTokenExpiresAt: new Date(new Date() / 2), user: {} };
+      var model = {
+        getRefreshToken: function() {},
+        revokeToken: function(refreshToken, callback) { callback(null, token); },
+        saveToken: function() {}
+      };
+      var grantType = new RefreshTokenGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.revokeToken(token).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('saveToken()', function() {
@@ -530,6 +569,18 @@ describe('RefreshTokenGrantType integration', function() {
         getRefreshToken: function() {},
         revokeToken: function() {},
         saveToken: function() { return token; }
+      };
+      var grantType = new RefreshTokenGrantType({ accessTokenLifetime: 123, model: model });
+
+      grantType.saveToken(token).should.be.an.instanceOf(Promise);
+    });
+
+    it('should support callbacks', function() {
+      var token = {};
+      var model = {
+        getRefreshToken: function() {},
+        revokeToken: function() {},
+        saveToken: function(tokenToSave, client, user, callback) { callback(null, token); }
       };
       var grantType = new RefreshTokenGrantType({ accessTokenLifetime: 123, model: model });
 

--- a/test/integration/handlers/authenticate-handler_test.js
+++ b/test/integration/handlers/authenticate-handler_test.js
@@ -410,6 +410,17 @@ describe('AuthenticateHandler integration', function() {
 
       handler.getAccessToken('foo').should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacks', function() {
+      var model = {
+        getAccessToken: function(token, callback) {
+          callback(null, { user: {} });
+        }
+      };
+      var handler = new AuthenticateHandler({ model: model });
+
+      handler.getAccessToken('foo').should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('validateAccessToken()', function() {
@@ -470,6 +481,18 @@ describe('AuthenticateHandler integration', function() {
         getAccessToken: function() {},
         verifyScope: function() {
           return true;
+        }
+      };
+      var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: model, scope: 'foo' });
+
+      handler.verifyScope('foo').should.be.an.instanceOf(Promise);
+    });
+
+    it('should support callbacks', function() {
+      var model = {
+        getAccessToken: function() {},
+        verifyScope: function(token, scope, callback) {
+          callback(null, true);
         }
       };
       var handler = new AuthenticateHandler({ addAcceptedScopesHeader: true, addAuthorizedScopesHeader: true, model: model, scope: 'foo' });

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -524,23 +524,6 @@ describe('AuthorizeHandler integration', function() {
         });
     });
 
-    it('should throw an error if `client` is missing', function() {
-      var model = {
-        getAccessToken: function() {},
-        getClient: function() {},
-        saveAuthorizationCode: function() {}
-      };
-      var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
-      var request = new Request({ body: { client_id: 12345, response_type: 'code' }, headers: {}, method: {}, query: {} });
-
-      return handler.getClient(request)
-        .then(should.fail)
-        .catch(function(e) {
-          e.should.be.an.instanceOf(InvalidClientError);
-          e.message.should.equal('Invalid client: client credentials are invalid');
-        });
-    });
-
     it('should throw an error if `client.grants` is missing', function() {
       var model = {
         getAccessToken: function() {},
@@ -653,25 +636,23 @@ describe('AuthorizeHandler integration', function() {
       handler.getClient(request).should.be.an.instanceOf(Promise);
     });
 
-    describe('with `client_id` in the request body', function() {
-      it('should return a client', function() {
-        var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
-        var model = {
-          getAccessToken: function() {},
-          getClient: function() {
-            return client;
-          },
-          saveAuthorizationCode: function() {}
-        };
-        var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
-        var request = new Request({ body: { client_id: 12345, response_type: 'code' }, headers: {}, method: {}, query: {} });
-
-        return handler.getClient(request)
-          .then(function(data) {
-            data.should.equal(client);
-          })
-          .catch(should.fail);
+    it('should support callbacks', function() {
+      var model = {
+        getAccessToken: function() {},
+        getClient: function(clientId, callback) {
+          callback(null, { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] });
+        },
+        saveAuthorizationCode: function() {}
+      };
+      var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
+      var request = new Request({
+        body: { client_id: 12345 },
+        headers: {},
+        method: {},
+        query: {}
       });
+
+      handler.getClient(request).should.be.an.instanceOf(Promise);
     });
 
     describe('with `client_id` in the request query', function() {
@@ -891,6 +872,19 @@ describe('AuthorizeHandler integration', function() {
         getClient: function() {},
         saveAuthorizationCode: function() {
           return {};
+        }
+      };
+      var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
+
+      handler.saveAuthorizationCode('foo', 'bar', 'biz', 'baz').should.be.an.instanceOf(Promise);
+    });
+
+    it('should support callbacks when calling `model.saveAuthorizationCode()`', function() {
+      var model = {
+        getAccessToken: function() {},
+        getClient: function() {},
+        saveAuthorizationCode: function(code, client, user, callback) {
+          return callback(null, true);
         }
       };
       var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -639,7 +639,8 @@ describe('AuthorizeHandler integration', function() {
     it('should support callbacks', function() {
       var model = {
         getAccessToken: function() {},
-        getClient: function(clientId, callback) {
+        getClient: function(clientId, clientSecret, callback) {
+          clientSecret.should.eql(null);
           callback(null, { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] });
         },
         saveAuthorizationCode: function() {}

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -445,7 +445,7 @@ describe('TokenHandler integration', function() {
       handler.getClient(request).should.be.an.instanceOf(Promise);
     });
 
-    it('should support callbacs', function() {
+    it('should support callbacks', function() {
       var model = {
         getClient: function(clientId, clientSecret, callback) { callback(null, { grants: [] }); },
         saveToken: function() {}

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -444,6 +444,17 @@ describe('TokenHandler integration', function() {
 
       handler.getClient(request).should.be.an.instanceOf(Promise);
     });
+
+    it('should support callbacs', function() {
+      var model = {
+        getClient: function(clientId, clientSecret, callback) { callback(null, { grants: [] }); },
+        saveToken: function() {}
+      };
+      var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+      var request = new Request({ body: { client_id: 12345, client_secret: 'secret' }, headers: {}, method: {}, query: {} });
+
+      handler.getClient(request).should.be.an.instanceOf(Promise);
+    });
   });
 
   describe('getClientCredentials()', function() {
@@ -596,8 +607,8 @@ describe('TokenHandler integration', function() {
     it('should throw an invalid grant error if a non-oauth error is thrown', function() {
       var client = { grants: ['password'] };
       var model = {
-        getClient: function() {},
-        getUser: function() {},
+        getClient: function(clientId, password, callback) { callback(null, client); },
+        getUser: function(uid, pwd, callback) { callback(); },
         saveToken: function() {}
       };
       var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -607,8 +607,8 @@ describe('TokenHandler integration', function() {
     it('should throw an invalid grant error if a non-oauth error is thrown', function() {
       var client = { grants: ['password'] };
       var model = {
-        getClient: function(clientId, password, callback) { callback(null, client); },
-        getUser: function(uid, pwd, callback) { callback(); },
+        getClient: function() {},
+        getUser: function() {},
         saveToken: function() {}
       };
       var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -58,8 +58,8 @@ describe('Server integration', function() {
 
     it('should return a promise', function() {
       var model = {
-        getAccessToken: function() {
-          return { user: {} };
+        getAccessToken: function(token, callback) {
+          callback(null, { user: {} });
         }
       };
       var server = new Server({ model: model });

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -58,8 +58,8 @@ describe('Server integration', function() {
 
     it('should return a promise', function() {
       var model = {
-        getAccessToken: function(token, callback) {
-          callback(null, { user: {} });
+        getAccessToken: function() {
+          return { user: {} };
         }
       };
       var server = new Server({ model: model });

--- a/test/unit/handlers/authorize-handler_test.js
+++ b/test/unit/handlers/authorize-handler_test.js
@@ -47,7 +47,7 @@ describe('AuthorizeHandler', function() {
       return handler.getClient(request)
         .then(function() {
           model.getClient.callCount.should.equal(1);
-          model.getClient.firstCall.args.should.have.length(1);
+          model.getClient.firstCall.args.should.have.length(2);
           model.getClient.firstCall.args[0].should.equal(12345);
         })
         .catch(should.fail);


### PR DESCRIPTION
The current library does not run well with node-style callback functions, which require promisification.  Bluebird's native promisify will only promisify node-style callback functions, but will break existing promises.  

* Added [promisify-any](https://www.npmjs.com/package/promisify-any) and invoked it on all model functions.  This library promisifies node-style callback functions, synchronous functions, generator functions, and keeps Promises intact.  
* Added tests for ensuring that raw callbacks work
* Added saveToken to its own `.then`.  
