### PR TITLE
#280 Add alwaysIssueNewRefreshToken server option

### DIFF
--- a/lib/grant-types/abstract-grant-type.js
+++ b/lib/grant-types/abstract-grant-type.js
@@ -28,6 +28,7 @@ function AbstractGrantType(options) {
   this.accessTokenLifetime = options.accessTokenLifetime;
   this.model = options.model;
   this.refreshTokenLifetime = options.refreshTokenLifetime;
+  this.alwaysIssueNewRefreshToken = options.alwaysIssueNewRefreshToken;
 }
 
 /**

--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -122,6 +122,11 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
  */
 
 RefreshTokenGrantType.prototype.revokeToken = function(token) {
+
+  if (this.alwaysIssueNewRefreshToken === false) {
+    return Promise.resolve(token);
+  }
+
   return Promise.try(this.model.revokeToken, token)
     .then(function(token) {
       if (!token) {
@@ -162,6 +167,11 @@ RefreshTokenGrantType.prototype.saveToken = function(user, client, scope) {
         refreshTokenExpiresAt: refreshTokenExpiresAt,
         scope: scope
       };
+
+      if (this.alwaysIssueNewRefreshToken === false) {
+        delete token.refreshToken;
+        delete token.refreshTokenExpiresAt;
+      }
 
       return this.model.saveToken(token, client, user);
     });

--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -155,14 +155,12 @@ RefreshTokenGrantType.prototype.saveToken = function(user, client, scope) {
       var token = {
         accessToken: accessToken,
         accessTokenExpiresAt: accessTokenExpiresAt,
-        refreshToken: refreshToken,
-        refreshTokenExpiresAt: refreshTokenExpiresAt,
         scope: scope
       };
 
-      if (this.alwaysIssueNewRefreshToken === false) {
-        delete token.refreshToken;
-        delete token.refreshTokenExpiresAt;
+      if (this.alwaysIssueNewRefreshToken !== false) {
+        token.refreshToken = refreshToken;
+        token.refreshTokenExpiresAt = refreshTokenExpiresAt;
       }
 
       return token;

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -58,6 +58,7 @@ function TokenHandler(options) {
   this.grantTypes = _.assign({}, grantTypes, options.extendedGrantTypes);
   this.model = options.model;
   this.refreshTokenLifetime = options.refreshTokenLifetime;
+  this.alwaysIssueNewRefreshToken = options.alwaysIssueNewRefreshToken !== false;
 }
 
 /**
@@ -211,7 +212,8 @@ TokenHandler.prototype.handleGrantType = function(request, client) {
   var options = {
     accessTokenLifetime: accessTokenLifetime,
     model: this.model,
-    refreshTokenLifetime: refreshTokenLifetime
+    refreshTokenLifetime: refreshTokenLifetime,
+    alwaysIssueNewRefreshToken: this.alwaysIssueNewRefreshToken
   };
 
   return new Type(options)

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -82,6 +82,38 @@ describe('TokenHandler integration', function() {
       handler.accessTokenLifetime.should.equal(accessTokenLifetime);
     });
 
+    it('should set the `alwaysIssueNewRefreshToken`', function() {
+      var alwaysIssueNewRefreshToken = true;
+      var model = {
+        getClient: function() {},
+        saveToken: function() {}
+      };
+      var handler = new TokenHandler({ accessTokenLifetime: 123, model: model, refreshTokenLifetime: 120, alwaysIssueNewRefreshToken: alwaysIssueNewRefreshToken });
+
+      handler.alwaysIssueNewRefreshToken.should.equal(alwaysIssueNewRefreshToken);
+    });
+
+    it('should set the `alwaysIssueNewRefreshToken` to false', function() {
+      var alwaysIssueNewRefreshToken = false;
+      var model = {
+        getClient: function() {},
+        saveToken: function() {}
+      };
+      var handler = new TokenHandler({ accessTokenLifetime: 123, model: model, refreshTokenLifetime: 120, alwaysIssueNewRefreshToken: alwaysIssueNewRefreshToken });
+
+      handler.alwaysIssueNewRefreshToken.should.equal(alwaysIssueNewRefreshToken);
+    });
+
+    it('should return the default `alwaysIssueNewRefreshToken` value', function() {
+      var model = {
+        getClient: function() {},
+        saveToken: function() {}
+      };
+      var handler = new TokenHandler({ accessTokenLifetime: 123, model: model, refreshTokenLifetime: 120 });
+
+      handler.alwaysIssueNewRefreshToken.should.equal(true);
+    });
+
     it('should set the `extendedGrantTypes`', function() {
       var extendedGrantTypes = { foo: 'bar' };
       var model = {


### PR DESCRIPTION
Add alwaysIssueNewRefreshToken server option

```
{Boolean} alwaysIssueNewRefreshToken
```

Default value is `true`

If false, the refresh token is not revoked and the new one is neither saved nor returned with an access token.  
