### PR TITLE
Generate token params

### DIFF
--- a/lib/grant-types/abstract-grant-type.js
+++ b/lib/grant-types/abstract-grant-type.js
@@ -35,9 +35,12 @@ function AbstractGrantType(options) {
  * Generate access token.
  */
 
-AbstractGrantType.prototype.generateAccessToken = function() {
+AbstractGrantType.prototype.generateAccessToken = function(client, user, scope) {
   if (this.model.generateAccessToken) {
-    return promisify(this.model.generateAccessToken)();
+    return promisify(this.model.generateAccessToken, 3)(client, user, scope)
+      .then(function(accessToken) {
+        return accessToken || tokenUtil.generateRandomToken();
+      });
   }
 
   return tokenUtil.generateRandomToken();
@@ -47,9 +50,12 @@ AbstractGrantType.prototype.generateAccessToken = function() {
  * Generate refresh token.
  */
 
-AbstractGrantType.prototype.generateRefreshToken = function() {
+AbstractGrantType.prototype.generateRefreshToken = function(client, user, scope) {
   if (this.model.generateRefreshToken) {
-    return promisify(this.model.generateRefreshToken)();
+    return promisify(this.model.generateRefreshToken, 3)(client, user, scope)
+      .then(function(refreshToken) {
+        return refreshToken || tokenUtil.generateRandomToken();
+      });
   }
 
   return tokenUtil.generateRandomToken();

--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -177,8 +177,8 @@ AuthorizationCodeGrantType.prototype.revokeAuthorizationCode = function(code) {
 AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authorizationCode, scope) {
   var fns = [
     this.validateScope(user, client, scope),
-    this.generateAccessToken(),
-    this.generateRefreshToken()
+    this.generateAccessToken(client, user, scope),
+    this.generateRefreshToken(client, user, scope)
   ];
 
   return Promise.all(fns)

--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -87,8 +87,8 @@ ClientCredentialsGrantType.prototype.getUserFromClient = function(client) {
 ClientCredentialsGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
     this.validateScope(user, client, scope),
-    this.generateAccessToken(),
-    this.getAccessTokenExpiresAt()
+    this.generateAccessToken(client, user, scope),
+    this.getAccessTokenExpiresAt(client, user, scope)
   ];
 
   return Promise.all(fns)

--- a/lib/grant-types/password-grant-type.js
+++ b/lib/grant-types/password-grant-type.js
@@ -105,8 +105,8 @@ PasswordGrantType.prototype.getUser = function(request) {
 PasswordGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
     this.validateScope(user, client, scope),
-    this.generateAccessToken(),
-    this.generateRefreshToken(),
+    this.generateAccessToken(client, user, scope),
+    this.generateRefreshToken(client, user, scope),
     this.getAccessTokenExpiresAt(),
     this.getRefreshTokenExpiresAt()
   ];

--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -139,8 +139,8 @@ RefreshTokenGrantType.prototype.revokeToken = function(token) {
 
 RefreshTokenGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
-    this.generateAccessToken(),
-    this.generateRefreshToken(),
+    this.generateAccessToken(client, user, scope),
+    this.generateRefreshToken(client, user, scope),
     this.getAccessTokenExpiresAt(),
     this.getRefreshTokenExpiresAt()
   ];

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -678,8 +678,8 @@ describe('TokenHandler integration', function() {
     it('should throw an invalid grant error if a non-oauth error is thrown', function() {
       var client = { grants: ['password'] };
       var model = {
-        getClient: function() {},
-        getUser: function() {},
+        getClient: function(clientId, password, callback) { callback(null, client); },
+        getUser: function(uid, pwd, callback) { callback(); },
         saveToken: function() {}
       };
       var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -58,8 +58,8 @@ describe('Server integration', function() {
 
     it('should return a promise', function() {
       var model = {
-        getAccessToken: function() {
-          return { user: {} };
+        getAccessToken: function(token, callback) {
+          callback(null, { user: {} });
         }
       };
       var server = new Server({ model: model });


### PR DESCRIPTION
Adds client, user, and scope as arguments to generateAccessToken and generateRefreshToken.  This allows such things as returning the same access token on a reauth if the token is not expired, as many oauth implementations do.  