### PR TITLE
don't check client_secret for password grant_type

### DIFF
--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -110,12 +110,13 @@ TokenHandler.prototype.handle = function(request, response) {
 
 TokenHandler.prototype.getClient = function(request, response) {
   var credentials = this.getClientCredentials(request);
+  var grantType = request.body.grant_type;
 
   if (!credentials.clientId) {
     throw new InvalidRequestError('Missing parameter: `client_id`');
   }
 
-  if (!credentials.clientSecret) {
+  if (grantType !== "password" && !credentials.clientSecret) {
     throw new InvalidRequestError('Missing parameter: `client_secret`');
   }
 


### PR DESCRIPTION
when using password grant_type the client_secret should not be present and therefore should not be enforced.
