### PR TITLE
Fixes #304: Add token lifetimes for the auth code grant

### DIFF
--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -72,7 +72,7 @@ AuthorizationCodeGrantType.prototype.handle = function(request, client) {
       return this.revokeAuthorizationCode(code);
     })
     .then(function(code) {
-      return this.saveToken(code.user, client, code.authorizationCode, code.scope);
+      return this.saveToken(code.user, client, code.scope);
     });
 };
 
@@ -174,20 +174,23 @@ AuthorizationCodeGrantType.prototype.revokeAuthorizationCode = function(code) {
  * Save token.
  */
 
-AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authorizationCode, scope) {
+AuthorizationCodeGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
     this.validateScope(user, client, scope),
     this.generateAccessToken(client, user, scope),
-    this.generateRefreshToken(client, user, scope)
+    this.generateRefreshToken(client, user, scope),
+    this.getAccessTokenExpiresAt(),
+    this.getRefreshTokenExpiresAt()
   ];
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(scope, accessToken, refreshToken) {
+    .spread(function(scope, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
-        authorizationCode: authorizationCode,
+        accessTokenExpiresAt: accessTokenExpiresAt,
         refreshToken: refreshToken,
+        refreshTokenExpiresAt: refreshTokenExpiresAt,
         scope: scope
       };
 

--- a/test/unit/grant-types/authorization-code-grant-type_test.js
+++ b/test/unit/grant-types/authorization-code-grant-type_test.js
@@ -70,12 +70,14 @@ describe('AuthorizationCodeGrantType', function() {
       sinon.stub(handler, 'validateScope').returns('foobiz');
       sinon.stub(handler, 'generateAccessToken').returns(Promise.resolve('foo'));
       sinon.stub(handler, 'generateRefreshToken').returns(Promise.resolve('bar'));
+      sinon.stub(handler, 'getAccessTokenExpiresAt').returns(Promise.resolve('biz'));
+      sinon.stub(handler, 'getRefreshTokenExpiresAt').returns(Promise.resolve('baz'));
 
-      return handler.saveToken(user, client, 'foobar', 'foobiz')
+      return handler.saveToken(user, client, 'foobiz')
         .then(function() {
           model.saveToken.callCount.should.equal(1);
           model.saveToken.firstCall.args.should.have.length(3);
-          model.saveToken.firstCall.args[0].should.eql({ accessToken: 'foo', authorizationCode: 'foobar', refreshToken: 'bar', scope: 'foobiz' });
+          model.saveToken.firstCall.args[0].should.eql({ accessToken: 'foo', accessTokenExpiresAt: 'biz', refreshToken: 'bar', refreshTokenExpiresAt: 'baz', scope: 'foobiz' });
           model.saveToken.firstCall.args[1].should.equal(client);
           model.saveToken.firstCall.args[2].should.equal(user);
         })


### PR DESCRIPTION
Fixes #304.

`authorizationCode` was removed from `AuthorizationCodeGrantType#saveToken`. (Why would anyone want to resave an authorization code that was already revoked?)

Instead, `accessTokenExpiresAt` and `refreshTokenExpiresAt` are generated and passed to `saveToken` on the model.
