### PR TITLE
Fix missing character range in validator

### DIFF
--- a/lib/validator/is.js
+++ b/lib/validator/is.js
@@ -8,7 +8,7 @@ var rules = {
   NCHAR: /^[\u002D|\u002E|\u005F|\w]+$/,
   NQCHAR: /^[\u0021|\u0023-\u005B|\u005D-\u007E]+$/,
   NQSCHAR: /^[\u0020-\u0021|\u0023-\u005B|\u005D-\u007E]+$/,
-  UNICODECHARNOCRLF: /^[\u0009|\u0020-\u007E|\uD7FF|\uE000-\uFFFD|\u10000-\u10FFFF]+$/,
+  UNICODECHARNOCRLF: /^[\u0009|\u0020-\u007E|\u0080-\uD7FF|\uE000-\uFFFD|\u10000-\u10FFFF]+$/,
   URI: /^[a-zA-Z][a-zA-Z0-9+.-]+:/,
   VSCHAR: /^[\u0020-\u007E]+$/
 };

--- a/test/integration/grant-types/password-grant-type_test.js
+++ b/test/integration/grant-types/password-grant-type_test.js
@@ -179,7 +179,7 @@ describe('PasswordGrantType integration', function() {
         saveToken: function() {}
       };
       var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
-      var request = new Request({ body: { username: 'øå€£‰', password: 'foobar' }, headers: {}, method: {}, query: {} });
+      var request = new Request({ body: { username: '\r\n', password: 'foobar' }, headers: {}, method: {}, query: {} });
 
       try {
         grantType.getUser(request);
@@ -197,7 +197,7 @@ describe('PasswordGrantType integration', function() {
         saveToken: function() {}
       };
       var grantType = new PasswordGrantType({ accessTokenLifetime: 123, model: model });
-      var request = new Request({ body: { username: 'foobar', password: 'øå€£‰' }, headers: {}, method: {}, query: {} });
+      var request = new Request({ body: { username: 'foobar', password: '\r\n' }, headers: {}, method: {}, query: {} });
 
       try {
         grantType.getUser(request);


### PR DESCRIPTION
According to [OAuth2 RFC Spec](https://tools.ietf.org/html/rfc6749#appendix-A), we are missing a character range in UNICODECHARNOCRLF (%x80-D7FF).
This leads to passwords using unicode symbols like €£ being wrongly considered invalid.
