### PR TITLE
Fixing typo in the getting started docs. On line 18 it is is camelCas…

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Complete, compliant and well tested module for implementing an OAuth2 server in 
 
 ```js
 var express = require('express');
-var oauthserver = require('express-oauth-server');
+var oauthServer = require('express-oauth-server');
 var app = express();
 
 var oauth = new oauthServer({ model: model });


### PR DESCRIPTION
…e, and thus node complains that "oauthServer" is not defined.