### PR TITLE
Remove standard-http-error to remove AGPL license.

### DIFF
--- a/lib/errors/invalid-argument-error.js
+++ b/lib/errors/invalid-argument-error.js
@@ -5,7 +5,7 @@
  */
 
 var _ = require('lodash');
-var StandardHttpError = require('standard-http-error');
+var OAuthError = require('./oauth-error');
 var util = require('util');
 
 /**
@@ -18,14 +18,14 @@ function InvalidArgumentError(message, properties) {
     name: 'invalid_argument'
   }, properties);
 
-  StandardHttpError.call(this, properties.code, message, properties);
+  OAuthError.call(this, message, properties);
 }
 
 /**
  * Inherit prototype.
  */
 
-util.inherits(InvalidArgumentError, StandardHttpError);
+util.inherits(InvalidArgumentError, OAuthError);
 
 /**
  * Export constructor.

--- a/lib/errors/oauth-error.js
+++ b/lib/errors/oauth-error.js
@@ -3,10 +3,9 @@
 /**
  * Module dependencies.
  */
-
-var StandardHttpError = require('standard-http-error');
+var _ = require('lodash');
 var util = require('util');
-
+var statuses = require('statuses');
 /**
  * Constructor.
  */
@@ -18,15 +17,20 @@ function OAuthError(messageOrError, properties) {
   if (error) {
     properties.inner = error;
   }
-
-  StandardHttpError.call(this, properties.code, message, properties);
+  if (_.isEmpty(message)) {
+    message = statuses[properties.code];
+  }
+  this.code = this.status = this.statusCode = properties.code;
+  this.message = message;
+  for (var key in properties) {
+    if (key !== 'code') {
+      this[key] = properties[key];
+    }
+  }
+  Error.captureStackTrace(this, OAuthError);
 }
 
-/**
- * Inherit prototype.
- */
-
-util.inherits(OAuthError, StandardHttpError);
+util.inherits(OAuthError, Error);
 
 /**
  * Export constructor.

--- a/lib/errors/oauth-error.js
+++ b/lib/errors/oauth-error.js
@@ -13,6 +13,12 @@ var statuses = require('statuses');
 function OAuthError(messageOrError, properties) {
   var message = messageOrError instanceof Error ? messageOrError.message : messageOrError;
   var error = messageOrError instanceof Error ? messageOrError : null;
+  if (_.isEmpty(properties))
+  {
+    properties = {};
+  }
+
+  _.defaults(properties, { code: 500 });
 
   if (error) {
     properties.inner = error;

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "camel-case": "^1.1.1",
     "lodash": "^3.3.1",
     "promisify-any": "2.0.1",
-    "standard-http-error": "^1.1.0",
+    "statuses": "^1.3.1",
     "type-is": "^1.6.0",
     "validator.js": "^1.1.1"
   },


### PR DESCRIPTION
Our policies require that we do not use code that is licensed under the AGPL.  I have replaced the standard-http-errors implementation with a similar style in the OAuthError class.  It now depends only on the MIT licensed statuses module from jshttp (https://github.com/jshttp/statuses)