### PR TITLE
Rename requiresClientAuthentication to requireClientAuthentication

### DIFF
--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -60,7 +60,7 @@ function TokenHandler(options) {
   this.model = options.model;
   this.refreshTokenLifetime = options.refreshTokenLifetime;
   this.allowExtendedTokenAttributes = options.allowExtendedTokenAttributes;
-  this.requiresClientAuthentication = options.requiresClientAuthentication || {};
+  this.requireClientAuthentication = options.requireClientAuthentication || {};
   this.alwaysIssueNewRefreshToken = options.alwaysIssueNewRefreshToken !== false;
 }
 
@@ -283,8 +283,8 @@ TokenHandler.prototype.updateErrorResponse = function(response, error) {
  * Given a grant type, check if client authentication is required
  */
 TokenHandler.prototype.isClientAuthenticationRequired = function(grantType) {
-  if(Object.keys(this.requiresClientAuthentication).length > 0) {
-    return (typeof this.requiresClientAuthentication[grantType] !== 'undefined') ? this.requiresClientAuthentication[grantType] : true;
+  if (Object.keys(this.requireClientAuthentication).length > 0) {
+    return (typeof this.requireClientAuthentication[grantType] !== 'undefined') ? this.requireClientAuthentication[grantType] : true;
   } else {
     return true;
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -64,7 +64,7 @@ OAuth2Server.prototype.token = function(request, response, options, callback) {
     accessTokenLifetime: 60 * 60,             // 1 hour.
     refreshTokenLifetime: 60 * 60 * 24 * 14,  // 2 weeks.
     allowExtendedTokenAttributes: false,
-    requiresClientAuthentication: {}          //defaults to true for all grant types
+    requireClientAuthentication: {}           // defaults to true for all grant types
   }, this.options, options);
 
   return new TokenHandler(options)

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -526,7 +526,7 @@ describe('TokenHandler integration', function() {
         .catch(should.fail);
     });
 
-    describe('with `password` grant type and `requiresClientAuthentication` is false', function() {
+    describe('with `password` grant type and `requireClientAuthentication` is false', function() {
 
       it('should return a client ', function() {
         var client = { id: 12345, grants: [] };
@@ -539,7 +539,7 @@ describe('TokenHandler integration', function() {
           accessTokenLifetime: 120,
           model: model,
           refreshTokenLifetime: 120,
-          requiresClientAuthentication: {
+          requireClientAuthentication: {
             password: false
           }
        });
@@ -624,13 +624,13 @@ describe('TokenHandler integration', function() {
       }
     });
 
-    describe('with `client_id` and grant type is `password` and `requiresClientAuthentication` is false', function() {
+    describe('with `client_id` and grant type is `password` and `requireClientAuthentication` is false', function() {
       it('should return a client', function() {
         var model = {
           getClient: function() {},
           saveToken: function() {}
         };
-        var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120, requiresClientAuthentication: { password: false} });
+        var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120, requireClientAuthentication: { password: false} });
         var request = new Request({ body: { client_id: 'foo', grant_type: 'password' }, headers: {}, method: {}, query: {} });
         var credentials = handler.getClientCredentials(request);
 


### PR DESCRIPTION
This change is made to align the spelling with all the other server options.

See #376.