### PR TITLE
Remove unused module dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,7 @@
     "lodash": "^3.3.1",
     "promisify-any": "2.0.1",
     "statuses": "^1.3.1",
-    "type-is": "^1.6.0",
-    "validator.js": "^1.1.1"
+    "type-is": "^1.6.0"
   },
   "devDependencies": {
     "jshint": "^2.9.1",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   "dependencies": {
     "basic-auth": "^1.0.0",
     "bluebird": "^2.9.13",
-    "camel-case": "^1.1.1",
     "lodash": "^3.3.1",
     "promisify-any": "2.0.1",
     "statuses": "^1.3.1",


### PR DESCRIPTION
Remove "camel-case" and "validator.js" from module dependencies. These dependencies were added by commit 2689d22419d21967a9f3349e98995c51b6ac9209 but apparently never used.