### PR TITLE
oauth.token promise, returns token object instead of sending response

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -29,6 +29,14 @@ app.oauth = oauthserver({
 
 app.all('/oauth/token', app.oauth.grant());
 
+app.get('/custom/token', function (req, res) {
+  
+  app.oauth.token(req)
+    .then(function(tokenRes) {
+      res.send(tokenRes);
+    })
+});
+
 app.get('/', app.oauth.authorise(), function (req, res) {
   res.send('Secret area');
 });

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -46,12 +46,16 @@ var fns = [
  * @param {Object}   res
  * @param {Function} next
  */
-function Grant (config, req, res, next) {
+function Grant(config, req, res, next, returnPromise) {
   this.config = config;
   this.model = config.model;
   this.now = new Date();
   this.req = req;
   this.res = res;
+
+  if (returnPromise) {
+    fns[fns.length - 1] = returnToken;
+  }
 
   runner(fns, this, next);
 }
@@ -452,4 +456,26 @@ function sendResponse (done) {
 
   if (this.config.continueAfterResponse)
     done();
+}
+
+/**
+ * Create an access token and call callback done with token response.
+ *
+ * @param  {Function} done
+ * @this   OAuth
+ */
+function returnToken(done) {
+
+  var response = {
+    token_type: 'bearer',
+    access_token: this.accessToken
+  };
+
+  if (this.config.accessTokenLifetime !== null) {
+    response.expires_in = this.config.accessTokenLifetime;
+  }
+
+  if (this.refreshToken) response.refresh_token = this.refreshToken;
+
+  done(null, response);
 }

--- a/lib/oauth2server.js
+++ b/lib/oauth2server.js
@@ -90,6 +90,30 @@ OAuth2Server.prototype.grant = function () {
 };
 
 /**
+ * Token Promise
+ *
+ * Returns promise that will grant tokens to valid requests,
+ * and return object with access token, expire period and token type
+ *
+ * @return {Function} middleware
+ */
+OAuth2Server.prototype.token = function (req) {
+  var self = this;
+
+  return new Promise((resolve, reject) => {
+
+    function cb(err, response) {
+      if(err){
+        return reject(err);
+      }
+      return resolve(response);
+    }
+
+    new Grant(self, req, {}, cb, true);
+  });
+};
+
+/**
  * Code Auth Grant Middleware
  *
  * @param  {Function} check Function will be called with req to check if the

--- a/lib/runner.js
+++ b/lib/runner.js
@@ -12,8 +12,8 @@ function runner (fns, context, next) {
   var last = fns.length - 1;
 
   (function run(pos) {
-    fns[pos].call(context, function (err) {
-      if (err || pos === last) return next(err);
+    fns[pos].call(context, function (err, res) {
+      if (err || pos === last) return next(err, res);
       run(++pos);
     });
   })(0);


### PR DESCRIPTION
This can enable using promise that will grant tokens to valid requests, and return object with access token, so that respond can be handled by users.

Can be published as version 2.2.2, to enable feature without migrating to version 3.