### PR TITLE
OAuth2Server#authenticate: Accept scope string in place of options

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -29,6 +29,10 @@ function OAuth2Server(options) {
  */
 
 OAuth2Server.prototype.authenticate = function(request, response, options, callback) {
+  if (typeof options === 'string') {
+    options = {scope: options};
+  }
+
   options = _.assign({
     addAcceptedScopesHeader: true,
     addAuthorizedScopesHeader: true,

--- a/test/unit/server_test.js
+++ b/test/unit/server_test.js
@@ -31,6 +31,24 @@ describe('Server', function() {
       AuthenticateHandler.prototype.handle.firstCall.args[0].should.equal('foo');
       AuthenticateHandler.prototype.handle.restore();
     });
+
+    it('should map string passed as `options` to `options.scope`', function() {
+      var model = {
+        getAccessToken: function() {},
+        verifyScope: function() {}
+      };
+      var server = new Server({ model: model });
+
+      sinon.stub(AuthenticateHandler.prototype, 'handle').returns(Promise.resolve());
+
+      server.authenticate('foo', 'bar', 'test');
+
+      AuthenticateHandler.prototype.handle.callCount.should.equal(1);
+      AuthenticateHandler.prototype.handle.firstCall.args[0].should.equal('foo');
+      AuthenticateHandler.prototype.handle.firstCall.args[1].should.equal('bar');
+      AuthenticateHandler.prototype.handle.firstCall.thisValue.should.have.property('scope', 'test');
+      AuthenticateHandler.prototype.handle.restore();
+    });
   });
 
   describe('authorize()', function() {


### PR DESCRIPTION
Resolves #379.

With this change
```
oauth.authenticate('test');
```
is the same as
```
oauth.authenticate({scope: 'test'});
```