### PR TITLE
Tokens never expires on BRT

### DIFF
--- a/lib/authorise.js
+++ b/lib/authorise.js
@@ -116,7 +116,7 @@ function checkToken (done) {
     }
 
     if (token.expires !== null &&
-      (!token.expires || token.expires < new Date())) {
+      (!token.expires || Date.parse(token.expires) < Date.parse(new Date()) )) {
       return done(error('invalid_token',
         'The access token provided has expired.'));
     }

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -134,7 +134,7 @@ function credsFromBody (req) {
  */
 function checkClient (done) {
   var self = this;
-  this.model.getClient(this.client.clientId, this.client.clientSecret,
+  this.model.getClient(this.client.clientId, this.client.clientSecret, this.config,
       function (err, client) {
     if (err) return done(error('server_error', false, err));
 

--- a/lib/grant.js
+++ b/lib/grant.js
@@ -253,7 +253,7 @@ function useRefreshTokenGrant (done) {
     if (!refreshToken || refreshToken.clientId !== self.client.clientId) {
       return done(error('invalid_grant', 'Invalid refresh token'));
     } else if (refreshToken.expires !== null &&
-        refreshToken.expires < self.now) {
+        Date.parse(refreshToken.expires) < Date.parse(self.now) ) {
       return done(error('invalid_grant', 'Refresh token has expired'));
     }
 


### PR DESCRIPTION
Sending two corrections for tokens never expires on BRT dates and one change to add a new feature to be able to configure the accessTokenLifetime and refreshTokenLifetime per client by implement getClient function on model. 