### PR TITLE
Potential Security Risk: accessTokenExpiresAt should be mandatory.

### DIFF
--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -216,11 +216,11 @@ AuthenticateHandler.prototype.getAccessToken = function(token) {
  */
 
 AuthenticateHandler.prototype.validateAccessToken = function(accessToken) {
-  if (!accessToken.accessTokenExpiresAt && !(accessToken.accessTokenExpiresAt instanceof Date)) {
+  if (!(accessToken.accessTokenExpiresAt instanceof Date)) {
     throw new ServerError('Server error: `accessTokenExpiresAt` must be a Date instance');
   }
 
-  if (accessToken.accessTokenExpiresAt && accessToken.accessTokenExpiresAt < new Date()) {
+  if (accessToken.accessTokenExpiresAt < new Date()) {
     throw new InvalidTokenError('Invalid token: access token has expired');
   }
 

--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -216,8 +216,8 @@ AuthenticateHandler.prototype.getAccessToken = function(token) {
  */
 
 AuthenticateHandler.prototype.validateAccessToken = function(accessToken) {
-  if (accessToken.accessTokenExpiresAt && !(accessToken.accessTokenExpiresAt instanceof Date)) {
-    throw new ServerError('Server error: `expires` must be a Date instance');
+  if (!accessToken.accessTokenExpiresAt && !(accessToken.accessTokenExpiresAt instanceof Date)) {
+    throw new ServerError('Server error: `accessTokenExpiresAt` must be a Date instance');
   }
 
   if (accessToken.accessTokenExpiresAt && accessToken.accessTokenExpiresAt < new Date()) {

--- a/test/integration/handlers/authenticate-handler_test.js
+++ b/test/integration/handlers/authenticate-handler_test.js
@@ -169,7 +169,10 @@ describe('AuthenticateHandler integration', function() {
     });
 
     it('should return an access token', function() {
-      var accessToken = { user: {} };
+      var accessToken = {
+        user: {},
+        accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+      };
       var model = {
         getAccessToken: function() {
           return accessToken;
@@ -439,7 +442,10 @@ describe('AuthenticateHandler integration', function() {
     });
 
     it('should return an access token', function() {
-      var accessToken = { user: {} };
+      var accessToken = {
+        user: {},
+        accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+      };
       var handler = new AuthenticateHandler({ model: { getAccessToken: function() {} } });
 
       handler.validateAccessToken(accessToken).should.equal(accessToken);

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -180,7 +180,10 @@ describe('AuthorizeHandler integration', function() {
     it('should redirect to an error response if a non-oauth error is thrown', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -215,7 +218,10 @@ describe('AuthorizeHandler integration', function() {
     it('should redirect to an error response if an oauth error is thrown', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -251,7 +257,11 @@ describe('AuthorizeHandler integration', function() {
       var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
       var model = {
         getAccessToken: function() {
-          return { client: client, user: {} };
+          return {
+            client: client,
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return client;
@@ -286,7 +296,10 @@ describe('AuthorizeHandler integration', function() {
     it('should redirect to an error response if `scope` is invalid', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -322,7 +335,10 @@ describe('AuthorizeHandler integration', function() {
     it('should redirect to an error response if `state` is missing', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -355,7 +371,10 @@ describe('AuthorizeHandler integration', function() {
     it('should redirect to an error response if `response_type` is invalid', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -390,7 +409,10 @@ describe('AuthorizeHandler integration', function() {
     it('should fail on invalid `response_type` before calling model.saveAuthorizationCode()', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -426,7 +448,11 @@ describe('AuthorizeHandler integration', function() {
       var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
       var model = {
         getAccessToken: function() {
-          return { client: client, user: {} };
+          return {
+            client: client,
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return client;
@@ -889,7 +915,10 @@ describe('AuthorizeHandler integration', function() {
       var user = {};
       var model = {
         getAccessToken: function() {
-          return { user: user };
+          return {
+            user: user,
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {},
         saveAuthorizationCode: function() {}

--- a/test/integration/server_test.js
+++ b/test/integration/server_test.js
@@ -40,7 +40,10 @@ describe('Server integration', function() {
     it('should set the default `options`', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         }
       };
       var server = new Server({ model: model });
@@ -59,7 +62,10 @@ describe('Server integration', function() {
     it('should return a promise', function() {
       var model = {
         getAccessToken: function(token, callback) {
-          callback(null, { user: {} });
+          callback(null, {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          });
         }
       };
       var server = new Server({ model: model });
@@ -73,7 +79,10 @@ describe('Server integration', function() {
     it('should support callbacks', function(next) {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         }
       };
       var server = new Server({ model: model });
@@ -88,7 +97,10 @@ describe('Server integration', function() {
     it('should set the default `options`', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -112,7 +124,10 @@ describe('Server integration', function() {
     it('should return a promise', function() {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
@@ -132,7 +147,10 @@ describe('Server integration', function() {
     it('should support callbacks', function(next) {
       var model = {
         getAccessToken: function() {
-          return { user: {} };
+          return {
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
         },
         getClient: function() {
           return { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };

--- a/test/unit/handlers/authenticate-handler_test.js
+++ b/test/unit/handlers/authenticate-handler_test.js
@@ -97,13 +97,15 @@ describe('AuthenticateHandler', function() {
   describe('validateAccessToken()', function() {
     it('should fail if token has no valid `accessTokenExpiresAt` date', function() {
       var model = {
-        getAccessToken: sinon.stub().returns({ user: {} })
+        getAccessToken: function() {}
       };
       var handler = new AuthenticateHandler({ model: model });
 
       var failed = false;
       try {
-        handler.validateAccessToken(model.getAccessToken);
+        handler.validateAccessToken({
+          user: {}
+        });
       }
       catch (err) {
         err.should.be.an.instanceOf(ServerError);
@@ -114,15 +116,14 @@ describe('AuthenticateHandler', function() {
 
     it('should succeed if token has valid `accessTokenExpiresAt` date', function() {
       var model = {
-        getAccessToken: sinon.stub().returns({
-          user: {},
-          accessTokenExpiresAt: new Date()
-        })
+        getAccessToken: function() {}
       };
       var handler = new AuthenticateHandler({ model: model });
-
       try {
-        handler.validateAccessToken(model.getAccessToken);
+        handler.validateAccessToken({
+          user: {},
+          accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+        });
       }
       catch (err) {
         should.fail();

--- a/test/unit/handlers/authenticate-handler_test.js
+++ b/test/unit/handlers/authenticate-handler_test.js
@@ -111,6 +111,23 @@ describe('AuthenticateHandler', function() {
       }
       failed.should.equal(true);
     });
+
+    it('should succeed if token has valid `accessTokenExpiresAt` date', function() {
+      var model = {
+        getAccessToken: sinon.stub().returns({
+          user: {},
+          accessTokenExpiresAt: new Date()
+        })
+      };
+      var handler = new AuthenticateHandler({ model: model });
+
+      try {
+        handler.validateAccessToken(model.getAccessToken);
+      }
+      catch (err) {
+        should.fail();
+      }
+    });
   });
 
   describe('verifyScope()', function() {

--- a/test/unit/handlers/authenticate-handler_test.js
+++ b/test/unit/handlers/authenticate-handler_test.js
@@ -8,6 +8,7 @@ var AuthenticateHandler = require('../../../lib/handlers/authenticate-handler');
 var Request = require('../../../lib/request');
 var sinon = require('sinon');
 var should = require('should');
+var ServerError = require('../../../lib/errors/server-error');
 
 /**
  * Test `AuthenticateHandler`.
@@ -90,6 +91,25 @@ describe('AuthenticateHandler', function() {
           model.getAccessToken.firstCall.args[0].should.equal('foo');
         })
         .catch(should.fail);
+    });
+  });
+
+  describe('validateAccessToken()', function() {
+    it('should fail if token has no valid `accessTokenExpiresAt` date', function() {
+      var model = {
+        getAccessToken: sinon.stub().returns({ user: {} })
+      };
+      var handler = new AuthenticateHandler({ model: model });
+
+      var failed = false;
+      try {
+        handler.validateAccessToken(model.getAccessToken);
+      }
+      catch (err) {
+        err.should.be.an.instanceOf(ServerError);
+        failed = true;
+      }
+      failed.should.equal(true);
     });
   });
 


### PR DESCRIPTION
Currently we don't prevent the user from "accidentally" returning an access token from the model that is not valid anymore. 

I had the case where my accessTokenExpiry property was named `expires` (as back in the old days). Therefore no check was run and no error was thrown. Meaning an access token once granted was valid infinite.

This pull requests makes it mandatory that always an `accessTokenExpiresAt` is returned as part of the `accessToken` from the `model.getAccessToken()`.

I hope I fixed the old unit tests in the correct manner. If not shoot me a message.