### PR TITLE
Allow missing or empty clientSecret when not required

### DIFF
--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -128,7 +128,7 @@ TokenHandler.prototype.getClient = function(request, response) {
     throw new InvalidRequestError('Invalid parameter: `client_id`');
   }
 
-  if (!is.vschar(credentials.clientSecret)) {
+  if (credentials.clientSecret && !is.vschar(credentials.clientSecret)) {
     throw new InvalidRequestError('Invalid parameter: `client_secret`');
   }
 

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -553,6 +553,38 @@ describe('TokenHandler integration', function() {
       });
     });
 
+    describe('with `password` grant type and `requireClientAuthentication` is false and Authorization header', function() {
+
+      it('should return a client ', function() {
+        var client = { id: 12345, grants: [] };
+        var model = {
+          getClient: function() { return client; },
+          saveToken: function() {}
+        };
+
+        var handler = new TokenHandler({
+          accessTokenLifetime: 120,
+          model: model,
+          refreshTokenLifetime: 120,
+          requireClientAuthentication: {
+            password: false
+          }
+	});
+        var request = new Request({
+	  body: { grant_type: 'password'},
+	  headers: { 'authorization': util.format('Basic %s', new Buffer('blah:').toString('base64')) },
+	  method: {},
+	  query: {}
+	});
+
+        return handler.getClient(request)
+          .then(function(data) {
+            data.should.equal(client);
+          })
+          .catch(should.fail);
+      });
+    });
+
     it('should support promises', function() {
       var model = {
         getClient: function() { return Promise.resolve({ grants: [] }); },


### PR DESCRIPTION
Includes case when client_secret is decoded as empty string from an Authorization header.

Solves #403. Includes test that fails on master.