### PR TITLE
readme: Update Slack badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,6 @@ npm test
 [travis-url]: https://travis-ci.org/oauthjs/node-oauth2-server
 [license-image]: https://img.shields.io/badge/license-MIT-blue.svg
 [license-url]: https://raw.githubusercontent.com/oauthjs/node-oauth2-server/master/LICENSE
-[slack-image]: https://img.shields.io/badge/slack-join-E01563.svg
-[slack-url]: https://oauthjs.slack.com
+[slack-image]: https://slack.oauthjs.org/badge.svg
+[slack-url]: https://slack.oauthjs.org
 


### PR DESCRIPTION
This PR updates the clickable Slack badge contained in the README to point our very own [Slackin landing page](https://slack.oauthjs.org). [Slackin](https://github.com/rauchg/slackin) enables users to request invite emails for themselves.

@oauthjs/core 
FYI: While setting up the service I went ahead and acquired the domain [oauthjs.org](https://oauthjs.org), hence the good looking invite link 😉