### PR TITLE
fix: issue correct expiry dates for tokens

### DIFF
--- a/lib/grant-types/abstract-grant-type.js
+++ b/lib/grant-types/abstract-grant-type.js
@@ -67,11 +67,7 @@ AbstractGrantType.prototype.generateRefreshToken = function(client, user, scope)
  */
 
 AbstractGrantType.prototype.getAccessTokenExpiresAt = function() {
-  var expires = new Date();
-
-  expires.setSeconds(expires.getSeconds() + this.accessTokenLifetime);
-
-  return expires;
+  return new Date(Date.now() + this.accessTokenLifetime * 1000);
 };
 
 /**
@@ -79,11 +75,7 @@ AbstractGrantType.prototype.getAccessTokenExpiresAt = function() {
  */
 
 AbstractGrantType.prototype.getRefreshTokenExpiresAt = function() {
-  var expires = new Date();
-
-  expires.setSeconds(expires.getSeconds() + this.refreshTokenLifetime);
-
-  return expires;
+  return new Date(Date.now() + this.refreshTokenLifetime * 1000);
 };
 
 /**


### PR DESCRIPTION
Related to a NodeJS (https://github.com/nodejs/node/issues/7074) and furthermore
V8 bug (https://bugs.chromium.org/p/v8/issues/detail?id=3637)

Solved by replaced seconds calculation with milliseconds.