### PR TITLE
 fix: validate requested scope on authorize request

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -97,11 +97,16 @@ AuthorizeHandler.prototype.handle = function(request, response) {
       var ResponseType;
 
       return Promise.bind(this)
-	.then(function() {
-          scope = this.getScope(request);
+        .then(function() {
+          var requestedScope = this.getScope(request);
 
-	  return this.generateAuthorizationCode(client, user, scope);
-	})
+          return this.validateScope(user, client, requestedScope);
+        })
+        .then(function(validScope) {
+          scope = validScope;
+
+          return this.generateAuthorizationCode(client, user, scope);
+        })
         .then(function(authorizationCode) {
           state = this.getState(request);
           ResponseType = this.getResponseType(request);
@@ -194,6 +199,24 @@ AuthorizeHandler.prototype.getClient = function(request) {
       }
       return client;
     });
+};
+
+/**
+ * Validate requested scope.
+ */
+AuthorizeHandler.prototype.validateScope = function(user, client, scope) {
+  if (this.model.validateScope) {
+    return promisify(this.model.validateScope, 3).call(this.model, user, client, scope)
+      .then(function (scope) {
+        if (!scope) {
+          throw new InvalidScopeError('Invalid scope: Requested scope is invalid');
+        }
+
+        return scope;
+      });
+  } else {
+    return Promise.resolve(scope);
+  }
 };
 
 /**

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -332,6 +332,50 @@ describe('AuthorizeHandler integration', function() {
         });
     });
 
+    it('should redirect to a successful response if `model.validateScope` is not defined', function() {
+      var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
+      var model = {
+        getAccessToken: function() {
+          return {
+            client: client,
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
+        },
+        getClient: function() {
+          return client;
+        },
+        saveAuthorizationCode: function() {
+          return { authorizationCode: 12345, client: client };
+        }
+      };
+      var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
+      var request = new Request({
+        body: {
+          client_id: 12345,
+          response_type: 'code'
+        },
+        headers: {
+          'Authorization': 'Bearer foo'
+        },
+        method: {},
+        query: {
+          scope: 'read',
+          state: 'foobar'
+        }
+      });
+      var response = new Response({ body: {}, headers: {} });
+
+      return handler.handle(request, response)
+        .then(function(data) {
+          data.should.eql({
+            authorizationCode: 12345,
+            client: client
+          });
+        })
+        .catch(should.fail);
+    });
+
     it('should redirect to an error response if `scope` is insufficient', function() {
       var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
       var model = {

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -332,6 +332,50 @@ describe('AuthorizeHandler integration', function() {
         });
     });
 
+    it('should redirect to an error response if `scope` is insufficient', function() {
+      var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
+      var model = {
+        getAccessToken: function() {
+          return {
+            client: client,
+            user: {},
+            accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+          };
+        },
+        getClient: function() {
+          return client;
+        },
+        saveAuthorizationCode: function() {
+          return { authorizationCode: 12345, client: client };
+        },
+        validateScope: function() {
+          return false;
+        }
+      };
+      var handler = new AuthorizeHandler({ authorizationCodeLifetime: 120, model: model });
+      var request = new Request({
+        body: {
+          client_id: 12345,
+          response_type: 'code'
+        },
+        headers: {
+          'Authorization': 'Bearer foo'
+        },
+        method: {},
+        query: {
+          scope: 'read',
+          state: 'foobar'
+        }
+      });
+      var response = new Response({ body: {}, headers: {} });
+
+      return handler.handle(request, response)
+        .then(should.fail)
+        .catch(function() {
+          response.get('location').should.equal('http://example.com/cb?error=invalid_scope&error_description=Invalid%20scope%3A%20Requested%20scope%20is%20invalid');
+        });
+    });
+
     it('should redirect to an error response if `state` is missing', function() {
       var model = {
         getAccessToken: function() {


### PR DESCRIPTION
Without validating the scope of a authorize request, a client could get access to unauthorized scopes.