### PR TITLE
Extend model object with request context

### DIFF
--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -63,6 +63,9 @@ AuthenticateHandler.prototype.handle = function(request, response) {
     throw new InvalidArgumentError('Invalid argument: `response` must be an instance of Response');
   }
 
+  // Extend model object with request
+  this.model.request = request;
+
   return Promise.bind(this)
     .then(function() {
       return this.getTokenFromRequest(request);

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -82,6 +82,9 @@ AuthorizeHandler.prototype.handle = function(request, response) {
     return Promise.reject(new AccessDeniedError('Access denied: user denied access to application'));
   }
 
+  // Extend model object with request
+  this.model.request = request;
+
   var fns = [
     this.getAuthorizationCodeLifetime(),
     this.getClient(request),

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -85,6 +85,9 @@ TokenHandler.prototype.handle = function(request, response) {
     return Promise.reject(new InvalidRequestError('Invalid request: content must be application/x-www-form-urlencoded'));
   }
 
+  // Extend model object with request
+  this.model.request = request;
+
   return Promise.bind(this)
     .then(function() {
       return this.getClient(request, response);

--- a/test/integration/handlers/authenticate-handler_test.js
+++ b/test/integration/handlers/authenticate-handler_test.js
@@ -168,7 +168,7 @@ describe('AuthenticateHandler integration', function() {
         });
     });
 
-    it('should return an access token', function() {
+    it('should return an access token with extend model obj with request', function() {
       var accessToken = {
         user: {},
         accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
@@ -192,6 +192,7 @@ describe('AuthenticateHandler integration', function() {
 
       return handler.handle(request, response)
         .then(function(data) {
+          model.request.should.equal(request);
           data.should.equal(accessToken);
         })
         .catch(should.fail);

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -444,7 +444,7 @@ describe('AuthorizeHandler integration', function() {
         });
     });
 
-    it('should return the `code` if successful', function() {
+    it('should return the `code` if successful with extend model obj with request', function() {
       var client = { grants: ['authorization_code'], redirectUris: ['http://example.com/cb'] };
       var model = {
         getAccessToken: function() {
@@ -479,6 +479,7 @@ describe('AuthorizeHandler integration', function() {
 
       return handler.handle(request, response)
         .then(function(data) {
+          model.request.should.equal(request);
           data.should.eql({
             authorizationCode: 12345,
             client: client

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -297,7 +297,7 @@ describe('TokenHandler integration', function() {
         });
     });
 
-    it('should return a bearer token if successful', function() {
+    it('should return a bearer token if successful with extend model obj with request', function() {
       var token = { accessToken: 'foo', client: {}, refreshToken: 'bar', scope: 'foobar', user: {} };
       var model = {
         getClient: function() { return { grants: ['password'] }; },
@@ -323,6 +323,7 @@ describe('TokenHandler integration', function() {
 
       return handler.handle(request, response)
         .then(function(data) {
+          model.request.should.equal(request);
           data.should.eql(token);
         })
         .catch(should.fail);

--- a/test/unit/handlers/authenticate-handler_test.js
+++ b/test/unit/handlers/authenticate-handler_test.js
@@ -6,6 +6,7 @@
 
 var AuthenticateHandler = require('../../../lib/handlers/authenticate-handler');
 var Request = require('../../../lib/request');
+var Response = require('../../../lib/response');
 var sinon = require('sinon');
 var should = require('should');
 var ServerError = require('../../../lib/errors/server-error');
@@ -15,6 +16,39 @@ var ServerError = require('../../../lib/errors/server-error');
  */
 
 describe('AuthenticateHandler', function() {
+  describe('handle()', function() {
+    it('should extend model object with request context', function() {
+      var model = {
+        getAccessToken: sinon.stub().returns({
+          user: 'foo',
+          accessTokenExpiresAt: new Date(new Date().getTime() + 10000)
+        }),
+        verifyScope: sinon.stub().returns(true)
+      };
+
+      var handler = new AuthenticateHandler({
+        addAcceptedScopesHeader: true,
+        addAuthorizedScopesHeader: true,
+        model: model,
+        scope: 'bar'
+      });
+      
+      var request = new Request({
+        body: {},
+        headers: { 'Authorization': 'Bearer foo' },
+        method: {},
+        query: {}
+      });
+      var response = new Response({});
+      
+      return handler.handle(request, response)
+        .then(function() {
+          model.request.should.equal(request);
+        })
+        .catch(should.fail);
+    });
+  });
+  
   describe('getTokenFromRequest()', function() {
     describe('with bearer token in the request authorization header', function() {
       it('should call `getTokenFromRequestHeader()`', function() {

--- a/test/unit/handlers/authorize-handler_test.js
+++ b/test/unit/handlers/authorize-handler_test.js
@@ -16,6 +16,40 @@ var should = require('should');
  */
 
 describe('AuthorizeHandler', function() {
+  describe('handle()', function() {
+    it('should extend model object with request context', function() {
+      var model = {
+        getClient: sinon.stub().returns({
+          grants: ['authorization_code'],
+          redirectUris: ['/abc']
+        }),
+        saveAuthorizationCode: sinon.stub().returns({ authorizationCode: 'code_abc' })
+      };
+      var handler = new AuthorizeHandler({
+        authenticateHandler: {
+          handle: sinon.stub().returns({ name: 'xyz' })
+        },
+        authorizationCodeLifetime: 123,
+        allowEmptyState: true,
+        model: model
+      });
+      
+      var request = new Request({
+        body: { client_id: '123', response_type: 'code' },
+        headers: {},
+        method: {},
+        query: {}
+      });
+      var response = new Response({});
+      
+      return handler.handle(request, response)
+        .then(function() {
+          model.request.should.equal(request);
+        })
+        .catch(should.fail);
+    });
+  });
+
   describe('generateAuthorizationCode()', function() {
     it('should call `model.generateAuthorizationCode()`', function() {
       var model = {


### PR DESCRIPTION
**Problem**:

There are many cases where you want to pass some parameters and access them in the model methods but you're only limited to the method signature params usually some attribute inside the `request` object. After going through some similar-issues (https://github.com/oauthjs/node-oauth2-server/issues/254, https://github.com/oauthjs/node-oauth2-server/issues/336) and PRs (https://github.com/oauthjs/node-oauth2-server/pull/320) found out there are a lot of usecases needed for different people implementing this lib.

**Example**:

In `saveToken` method I need to pass and save `consentId` attribute in the token table from the request body, as follow:

```
const saveToken = (token, client, user) => {
    const { consentId } = this.request.body;
    ...
}
```

**Suggested solution (_Quick-win_)**:

Extend `model` object with `request` context in the handlers (`authorize`, `authenticate`, `token`) so that it can be accessible in any of the model methods, also it won't break the current tests.

_**Note**_:

Right now, I forked the lib and did this minimal change as a quick-win but it'd be better if this issue is fixed on the lib so I still can refer to the original lib no my forked one.

Any feedback or change requests are welcome! Thanks!