### PR TITLE
Breaking Change: Set server_error Code to 500

### DIFF
--- a/lib/errors/server-error.js
+++ b/lib/errors/server-error.js
@@ -18,7 +18,7 @@ var util = require('util');
 
 function ServerError(message, properties) {
   properties = _.assign({
-    code: 503,
+    code: 500,
     name: 'server_error'
   }, properties);
 

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -293,7 +293,7 @@ describe('TokenHandler integration', function() {
         .then(should.fail)
         .catch(function() {
           response.body.should.eql({ error: 'server_error', error_description: 'Unhandled exception' });
-          response.status.should.equal(503);
+          response.status.should.equal(500);
         });
     });
 


### PR DESCRIPTION
As discussed in #461, error code 500 would fit better for server_error.

[RFC 6749](https://tools.ietf.org/html/rfc6749#section-4.1.2.1) also mentions 500 in the corresponding section:

> This error code is needed because a 500 Internal Server Error HTTP status code cannot be returned to the client via an HTTP redirect.

closes #461