### PR TITLE
Number of arguments MUST be passed

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -135,7 +135,7 @@ AuthorizeHandler.prototype.handle = function(request, response) {
 
 AuthorizeHandler.prototype.generateAuthorizationCode = function(client, user, scope) {
   if (this.model.generateAuthorizationCode) {
-    return promisify(this.model.generateAuthorizationCode).call(this.model, client, user, scope);
+    return promisify(this.model.generateAuthorizationCode, 3).call(this.model, client, user, scope);
   }
   return tokenUtil.generateRandomToken();
 };


### PR DESCRIPTION
> If the function expects arguments, the number of arguments (not including the callback) MUST be provided as a 2nd argument to promisify.

https://www.npmjs.com/package/promisify-any#promisifying

