### PR TITLE
fix: support object returned by the response.getHeaders() when create Response

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -12,9 +12,13 @@ function Response(options) {
   this.status = 200;
 
   // Store the headers in lower case.
-  for (var field in options.headers) {
-    if (options.headers.hasOwnProperty(field)) {
-      this.headers[field.toLowerCase()] = options.headers[field];
+  var headers = options.headers || {};
+  for (var field in headers) {
+    // The object returned by the response.getHeaders() method does not prototypically inherit from the JavaScript Object
+    // https://nodejs.org/dist/latest/docs/api/http.html#http_response_getheaders
+    // koa use response.getHeaders() to get response headers.
+    if (Object.prototype.hasOwnProperty.call(headers, field)) {
+      this.headers[field.toLowerCase()] = headers[field];
     }
   }
 

--- a/test/integration/response_test.js
+++ b/test/integration/response_test.js
@@ -29,6 +29,14 @@ describe('Response integration', function() {
 
       response.status.should.equal(200);
     });
+
+    it('should set the `headers` with Object.create(null)', function() {
+      var headers = Object.create(null);
+      headers.foo = 'bar';
+      var response = new Response({ body: {}, headers: headers });
+
+      response.headers.should.eql({ foo: 'bar' });
+    });
   });
 
   describe('get()', function() {


### PR DESCRIPTION
koa use response.getHeaders() to get response headers, and the object returned by the response.getHeaders() method does not prototypically inherit from the JavaScript Object