### PR TITLE
fix(vuln): Update lodash to address CVE-2018-3721

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   "dependencies": {
     "basic-auth": "1.1.0",
     "bluebird": "3.5.0",
-    "lodash": "4.17.4",
+    "lodash": "4.17.10",
     "promisify-any": "2.0.1",
     "statuses": "1.3.1",
     "type-is": "1.6.15"


### PR DESCRIPTION
https://hackerone.com/reports/310443
https://nodesecurity.io/advisories/577

> Versions of lodash before 4.17.5 are vulnerable to prototype pollution.
>
> The vulnerable functions are 'defaultsDeep', 'merge', and 'mergeWith' which allow a malicious user to modify the prototype of Object via __proto__ causing the addition or modification of an existing property that will exist on all objects.

http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-3721

you probably want to cut a minor release and publish to npm ASAP so users can remediate, please let me know if you want me to bump version in package.json :)