### PR TITLE
docs: Ensure accessTokenExpiresAt is required

### DIFF
--- a/docs/model/spec.rst
+++ b/docs/model/spec.rst
@@ -195,7 +195,7 @@ An ``Object`` representing the access token and associated data.
 +------------------------------+--------+--------------------------------------------------+
 | token.accessToken            | String | The access token passed to ``getAccessToken()``. |
 +------------------------------+--------+--------------------------------------------------+
-| [token.accessTokenExpiresAt] | Date   | The expiry time of the access token.             |
+| token.accessTokenExpiresAt   | Date   | The expiry time of the access token.             |
 +------------------------------+--------+--------------------------------------------------+
 | [token.scope]                | String | The authorized scope of the access token.        |
 +------------------------------+--------+--------------------------------------------------+


### PR DESCRIPTION
See [comment here](https://github.com/oauthjs/node-oauth2-server/issues/490#issuecomment-388726161) indicating that the documentation is incorrect; This simply brings the documentation in line with the implementation.