### PR TITLE
Specify arg count when promisifying generateAuthorizationCode

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -135,7 +135,7 @@ AuthorizeHandler.prototype.handle = function(request, response) {
 
 AuthorizeHandler.prototype.generateAuthorizationCode = function(client, user, scope) {
   if (this.model.generateAuthorizationCode) {
-    return promisify(this.model.generateAuthorizationCode).call(this.model, client, user, scope);
+    return promisify(this.model.generateAuthorizationCode, 3).call(this.model, client, user, scope);
   }
   return tokenUtil.generateRandomToken();
 };


### PR DESCRIPTION
This call doesn't seem to finish when specifying `generateAuthorizationCode` as an `async` function using TypeScript.

I tried to create a unit test for this case in this repository but couldn't get it to fail so I am guessing that this works by accident for JS.

But obviously this call to promisify is incorrect, as the `promisify-any` documentation mentions:

> If the function expects arguments, the number of arguments (not including the callback) MUST be provided as a 2nd argument to promisify.