### PR TITLE
fix: authorization_code grant should not be required in implicit flow

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -147,6 +147,7 @@ AuthorizeHandler.prototype.getClient = function(request) {
   if (redirectUri && !is.uri(redirectUri)) {
     throw new InvalidRequestError('Invalid request: `redirect_uri` is not a valid URI');
   }
+
   return promisify(this.model.getClient, 2).call(this.model, clientId, null)
     .then(function(client) {
       if (!client) {
@@ -157,7 +158,10 @@ AuthorizeHandler.prototype.getClient = function(request) {
         throw new InvalidClientError('Invalid client: missing client `grants`');
       }
 
-      if (!_.includes(client.grants, 'authorization_code')) {
+      var responseType = request.body.response_type || request.query.response_type;
+      var requestedGrantType = responseType === 'token' ? 'implicit' : 'authorization_code';
+
+      if (!_.includes(client.grants, requestedGrantType)) {
         throw new UnauthorizedClientError('Unauthorized client: `grant_type` is invalid');
       }
 
@@ -168,6 +172,7 @@ AuthorizeHandler.prototype.getClient = function(request) {
       if (redirectUri && !_.includes(client.redirectUris, redirectUri)) {
         throw new InvalidClientError('Invalid client: `redirect_uri` does not match client value');
       }
+
       return client;
     });
 };

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
     {
       "name": "Jonathon Hill",
       "email": "jhill9693@gmail.com"
+    },
+    {
+      "name": "Marco Lüthy",
+      "email": "marco.luethy@gmail.com"
     }
   ],
   "main": "index.js",


### PR DESCRIPTION
This is a follow-up to #464 (implicit grant flow). It fixes a bug where the `authorization_code` grant was required in the client's `grants` array. However, for the implicit grant flow, only the `implicit` grant should be required.

Closes #520