### PR TITLE
Allow "allowed" parameter to be fetched from  body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,8 @@
 * BREAKING: Remove support for node v4
 * new: Added revoke-handler to revoke access token
 * new: Added implicit grant flow
-* new: Switch from jshint to eslint
+* new: Switch from jshint to eslin
+* fix: authorization_code grant should not be required in implicit flowt
 
 ### 3.1.0
 * new: Added package-lock.json

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -69,7 +69,7 @@ AuthorizeHandler.prototype.handle = function(request, response) {
     throw new InvalidArgumentError('Invalid argument: `response` must be an instance of Response');
   }
 
-  if ('false' === request.query.allowed) {
+  if ('false' === request.query.allowed || 'false' === request.body.allowed) {
     return Promise.reject(new AccessDeniedError('Access denied: user denied access to application'));
   }
 


### PR DESCRIPTION
On most "authorize" flows the authorization step is a form post to request permissions from a user, so this parameter should be fetched from the body. In fact, IMHO, it should not be fetched from the query.