### PR TITLE
WWW-Authenticate headers

### DIFF
--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -87,12 +87,21 @@ AuthenticateHandler.prototype.handle = function(request, response) {
       return this.updateResponse(response, token);
     })
     .catch(function(e) {
-      // Include the "WWW-Authenticate" response header field if the client
-      // lacks any authentication information.
+      // Include the "WWW-Authenticate" response header field if the token authentication fails
       //
       // @see https://tools.ietf.org/html/rfc6750#section-3.1
-      if (e instanceof UnauthorizedRequestError) {
-        response.set('WWW-Authenticate', 'Bearer realm="Service"');
+      if (e instanceof InvalidRequestError || e instanceof InvalidTokenError || e instanceof InsufficientScopeError || e instanceof UnauthorizedRequestError) {
+
+        if(e instanceof UnauthorizedRequestError)
+          response.set('WWW-Authenticate', 'Bearer realm="Service"');
+        else 
+        {
+          if(e.message)
+            response.set('WWW-Authenticate', `Bearer realm="Service";error="${e.name}";error_description="${e.message}"`);
+          else
+            response.set('WWW-Authenticate', `Bearer realm="Service";error="${e.name}"`);
+        }
+
       }
 
       if (!(e instanceof OAuthError)) {


### PR DESCRIPTION
Add the `WWW-Authenticate` header any time the token authentication fails, as described in [Section 3.1 of RFC 6750](https://tools.ietf.org/html/rfc6750#section-3.1)