### PR TITLE
`rokenToken` is not required if alwaysIssueNewRefreshToken = false

### DIFF
--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -29,7 +29,7 @@ function RefreshTokenGrantType(options) {
     throw new InvalidArgumentError('Invalid argument: model does not implement `getRefreshToken()`');
   }
 
-  if (!options.model.revokeToken) {
+  if (options.alwaysIssueNewRefreshToken !== false && !options.model.revokeToken) {
     throw new InvalidArgumentError('Invalid argument: model does not implement `revokeToken()`');
   }
 


### PR DESCRIPTION
`revokeToken` wil not be called if  server option `alwaysIssueNewRefreshToken` is `false`.