### PR TITLE
Fix aguments passed to model.generateAuthorizationCode and context loss

### DIFF
--- a/lib/response-types/code-response-type.js
+++ b/lib/response-types/code-response-type.js
@@ -7,6 +7,7 @@
 var InvalidArgumentError = require('../errors/invalid-argument-error');
 var tokenUtil = require('../utils/token-util');
 var Promise = require('bluebird');
+var promisify = require('promisify-any').use(Promise);
 
 /**
  * Constructor.
@@ -54,7 +55,7 @@ CodeResponseType.prototype.handle = function(request, client, user, uri, scope) 
   }
 
   var fns = [
-    this.generateAuthorizationCode(),
+    this.generateAuthorizationCode(client, user, scope),
     this.getAuthorizationCodeExpiresAt(client)
   ];
 
@@ -102,16 +103,16 @@ CodeResponseType.prototype.saveAuthorizationCode = function(authorizationCode, e
     scope: scope
   };
 
-  return Promise.try(this.model.saveAuthorizationCode, [code, client, user]);
+  return promisify(this.model.saveAuthorizationCode, 3).call(this.model, code, client, user);
 };
 
 /**
  * Generate authorization code.
  */
 
-CodeResponseType.prototype.generateAuthorizationCode = function() {
+CodeResponseType.prototype.generateAuthorizationCode = function(client, user, scope) {
   if (this.model.generateAuthorizationCode) {
-    return Promise.try(this.model.generateAuthorizationCode);
+    return promisify(this.model.generateAuthorizationCode, 3).call(this.model, client, user, scope);
   }
 
   return tokenUtil.generateRandomToken();


### PR DESCRIPTION
I recently switched from official release v3.0.1 to unofficial dev release v4.0.0-dev.2 because I needed Implicit grant support which has been merged in dev branch (#464).

Since I moved to v4.0.0-dev.2, I encontered the following issues that broke the integration of oauth2-server in my application:
* I implemented `generateAuthorizationCode` function in my model, and with release v4.0.0-dev.2:
    * the arguments `client`, `user` and `scope` were no longer passed to the model function
    * the context was lost in `generateAuthorizationCode` and `saveAuthorizationCode` model functions (`this` was undefined instead of being the model's context)

I propose this PR to fix these 2 issues.

--
Commit message:
* Fixed arguments client, user, scope not passed to function generateAuthorizationCode (as specified in model https://oauth2-server.readthedocs.io/en/latest/model/spec.html#generateauthorizationcode-client-user-scope-callback)
* Fixed context loss when calling functions saveAuthorizationCode and generateAuthorizationCode (this was not bind to model's method)