### PR TITLE
Add token_type and expires_in to Implicit grant response

### DIFF
--- a/lib/response-types/token-response-type.js
+++ b/lib/response-types/token-response-type.js
@@ -71,7 +71,10 @@ TokenResponseType.prototype.getAccessTokenLifetime = function(client) {
  */
 
 TokenResponseType.prototype.buildRedirectUri = function(redirectUri) {
-  return this.setRedirectUriParam(redirectUri, 'access_token', this.accessToken);
+  redirectUri = this.setRedirectUriParam(redirectUri, 'access_token', this.accessToken);
+  redirectUri = this.setRedirectUriParam(redirectUri, 'token_type', 'access_token');
+  redirectUri = this.setRedirectUriParam(redirectUri, 'expires_in', this.accessTokenLifetime);
+  return redirectUri;
 };
 
 /**

--- a/test/integration/handlers/authorize-handler_test.js
+++ b/test/integration/handlers/authorize-handler_test.js
@@ -250,9 +250,9 @@ describe('AuthorizeHandler integration', function() {
     });
 
 
-    it('given an implicit grant flow, should redirect to a successful response with `token` and `state` if successful', function() {
+    it('given an implicit grant flow, should redirect to a successful response with `token`, `token_type`, `expires_in` and `state` if successful', function() {
       var client = { grants: ['implicit'], redirectUris: ['http://example.com/cb'] };
-      var token = { accessToken: 'foobar-token' }
+      var token = { accessToken: 'foobar-token' };
       var model = {
         getAccessToken: function() {
           return {
@@ -284,7 +284,7 @@ describe('AuthorizeHandler integration', function() {
 
       return handler.handle(request, response)
         .then(function() {
-          response.get('location').should.equal('http://example.com/cb#access_token=foobar-token&state=foobar');
+          response.get('location').should.equal('http://example.com/cb#access_token=foobar-token&token_type=access_token&expires_in=120&state=foobar');
         })
         .catch(should.fail);
     });

--- a/test/integration/response-types/token-response-type_test.js
+++ b/test/integration/response-types/token-response-type_test.js
@@ -62,7 +62,7 @@ describe('TokenResponseType integration', function() {
       }
     });
 
-    it('should return the new redirect uri and set `access_token` and `state` in the query', function() {
+    it('should return the new redirect uri and set `access_token`, `token_type`, `expires_in` and `state` in the fragment', function() {
       var responseType = new TokenResponseType({
         accessTokenLifetime: 120,
         model: {}
@@ -71,10 +71,10 @@ describe('TokenResponseType integration', function() {
       responseType.accessToken = 'foobar-token';
       var redirectUri = responseType.buildRedirectUri(url.parse('http://example.com/cb'));
 
-      url.format(redirectUri).should.equal('http://example.com/cb#access_token=foobar-token');
+      url.format(redirectUri).should.equal('http://example.com/cb#access_token=foobar-token&token_type=access_token&expires_in=120');
     });
 
-    it('should return the new redirect uri and append `access_token` and `state` in the query', function() {
+    it('should return the new redirect uri and append `access_token`, `token_type`, `expires_in` and `state` in the fragment', function() {
       var responseType = new TokenResponseType({
         accessTokenLifetime: 120,
         model: {}
@@ -83,7 +83,7 @@ describe('TokenResponseType integration', function() {
       responseType.accessToken = 'foobar-token';
       var redirectUri = responseType.buildRedirectUri(url.parse('http://example.com/cb?foo=bar', true));
 
-      url.format(redirectUri).should.equal('http://example.com/cb?foo=bar#access_token=foobar-token');
+      url.format(redirectUri).should.equal('http://example.com/cb?foo=bar#access_token=foobar-token&token_type=access_token&expires_in=120');
     });
   });
 });


### PR DESCRIPTION
According to [rfc6749](https://tools.ietf.org/html/rfc6749#section-4.2.2), access token response type for Implicit grant must contain `token_type` and should contain `expires_in` in fragment component.

I added these parameters in the response and updated the tests accordingly.