### PR TITLE
Passing validated scope into generateAccessToken

### DIFF
--- a/lib/grant-types/client-credentials-grant-type.js
+++ b/lib/grant-types/client-credentials-grant-type.js
@@ -54,13 +54,19 @@ ClientCredentialsGrantType.prototype.handle = function(request, client) {
     throw new InvalidArgumentError('Missing parameter: `client`');
   }
 
-  var scope = this.getScope(request);
+  var scope = this.getScope(request),
+    user;
 
   return Promise.bind(this)
     .then(function() {
       return this.getUserFromClient(client);
     })
-    .then(function(user) {
+    .then(function(validated) {
+      user = validated;
+      return this.validateScope(user, client, scope);
+    })
+    .then(function(validated) {
+      scope = validated;
       return this.saveToken(user, client, scope);
     });
 };
@@ -86,14 +92,13 @@ ClientCredentialsGrantType.prototype.getUserFromClient = function(client) {
 
 ClientCredentialsGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
-    this.validateScope(user, client, scope),
     this.generateAccessToken(client, user, scope),
     this.getAccessTokenExpiresAt(client, user, scope)
   ];
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(scope, accessToken, accessTokenExpiresAt) {
+    .spread(function(accessToken, accessTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
         accessTokenExpiresAt: accessTokenExpiresAt,

--- a/lib/grant-types/implicit-grant-type.js
+++ b/lib/grant-types/implicit-grant-type.js
@@ -54,7 +54,14 @@ ImplicitGrantType.prototype.handle = function(request, client) {
     throw new InvalidArgumentError('Missing parameter: `client`');
   }
 
-  return this.saveToken(this.user, client, this.scope);
+  return Promise.bind(this)
+    .then(function() {
+      return this.validateScope(this.user, client, this.scope);
+    })
+    .then(function(validated) {
+      this.scope = validated;
+      return this.saveToken(this.user, client, this.scope);
+    });
 };
 
 /**
@@ -63,14 +70,13 @@ ImplicitGrantType.prototype.handle = function(request, client) {
 
 ImplicitGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
-    this.validateScope(user, client, scope),
     this.generateAccessToken(client, user, scope),
     this.getAccessTokenExpiresAt()
   ];
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(scope, accessToken, accessTokenExpiresAt) {
+    .spread(function(accessToken, accessTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
         accessTokenExpiresAt: accessTokenExpiresAt,

--- a/lib/grant-types/password-grant-type.js
+++ b/lib/grant-types/password-grant-type.js
@@ -56,13 +56,19 @@ PasswordGrantType.prototype.handle = function(request, client) {
     throw new InvalidArgumentError('Missing parameter: `client`');
   }
 
-  var scope = this.getScope(request);
+  var scope = this.getScope(request),
+    user;
 
   return Promise.bind(this)
     .then(function() {
       return this.getUser(request);
     })
-    .then(function(user) {
+    .then(function(validated) {
+      user = validated;
+      return this.validateScope(user, client, scope);
+    })
+    .then(function(validated) {
+      scope = validated;
       return this.saveToken(user, client, scope);
     });
 };
@@ -104,7 +110,6 @@ PasswordGrantType.prototype.getUser = function(request) {
 
 PasswordGrantType.prototype.saveToken = function(user, client, scope) {
   var fns = [
-    this.validateScope(user, client, scope),
     this.generateAccessToken(client, user, scope),
     this.generateRefreshToken(client, user, scope),
     this.getAccessTokenExpiresAt(),
@@ -113,7 +118,7 @@ PasswordGrantType.prototype.saveToken = function(user, client, scope) {
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(scope, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
+    .spread(function(accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
         accessTokenExpiresAt: accessTokenExpiresAt,

--- a/test/unit/grant-types/implicit-grant-type_test.js
+++ b/test/unit/grant-types/implicit-grant-type_test.js
@@ -27,7 +27,7 @@ describe('ImplicitGrantType', function() {
         user: user
       });
 
-      sinon.stub(handler, 'validateScope').returns('foobar-scope');
+      sinon.stub(handler, 'validateScope').returns('foobar');
       sinon.stub(handler, 'generateAccessToken').returns(Promise.resolve('foobar-token'));
       sinon.stub(handler, 'getAccessTokenExpiresAt').returns(Promise.resolve('foo-1234'));
 
@@ -38,7 +38,7 @@ describe('ImplicitGrantType', function() {
           model.saveToken.firstCall.args[0].should.eql({
             accessToken: 'foobar-token',
             accessTokenExpiresAt: 'foo-1234',
-            scope: 'foobar-scope'
+            scope: 'foobar'
           });
           model.saveToken.firstCall.args[1].should.equal(client);
           model.saveToken.firstCall.args[2].should.equal(user);


### PR DESCRIPTION
The access token was getting generated with the requested scope rather than the validated one. Fixes #550 