### PR TITLE
RFC 6749#4.1.2.1 - fix order of error handling

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -78,10 +78,6 @@ AuthorizeHandler.prototype.handle = function(request, response) {
     throw new InvalidArgumentError('Invalid argument: `response` must be an instance of Response');
   }
 
-  // if ('false' === request.query.allowed) {
-  //   return Promise.reject(new AccessDeniedError('Access denied: user denied access to application'));
-  // }
-
   var fns = [
     this.getAuthorizationCodeLifetime(),
     this.getClient(request),

--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -78,9 +78,9 @@ AuthorizeHandler.prototype.handle = function(request, response) {
     throw new InvalidArgumentError('Invalid argument: `response` must be an instance of Response');
   }
 
-  if ('false' === request.query.allowed) {
-    return Promise.reject(new AccessDeniedError('Access denied: user denied access to application'));
-  }
+  // if ('false' === request.query.allowed) {
+  //   return Promise.reject(new AccessDeniedError('Access denied: user denied access to application'));
+  // }
 
   var fns = [
     this.getAuthorizationCodeLifetime(),
@@ -97,14 +97,19 @@ AuthorizeHandler.prototype.handle = function(request, response) {
       var ResponseType;
 
       return Promise.bind(this)
-	.then(function() {
+        .then(function() {
           scope = this.getScope(request);
-
-	  return this.generateAuthorizationCode(client, user, scope);
-	})
-        .then(function(authorizationCode) {
           state = this.getState(request);
           ResponseType = this.getResponseType(request);
+        })
+        .then(function() {
+          if ('false' === request.query.allowed) {
+            return Promise.reject(new AccessDeniedError('Access denied: user denied access to application'));
+          }
+
+      	  return this.generateAuthorizationCode(client, user, scope);
+      	})
+        .then(function(authorizationCode) {
 
           return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, uri, user);
         })


### PR DESCRIPTION
According to [https://tools.ietf.org/html/rfc6749#section-4.1.2.1](https://tools.ietf.org/html/rfc6749#section-4.1.2.1), only when the `redirect_uri` & `client_id` were correct, the authorisation server should inform the client that user had denied access.

The change is to move validation of resource owner approval after the
`redirect_uri` & `client_id` validation so the correct redirect url is computed.