### PR TITLE
fix: Bearer regular expression matching in authenticate handler

### DIFF
--- a/lib/handlers/authenticate-handler.ts
+++ b/lib/handlers/authenticate-handler.ts
@@ -145,7 +145,7 @@ export class AuthenticateHandler {
 
   getTokenFromRequestHeader(request: Request) {
     const token = request.get('Authorization');
-    const matches = token.match(/Bearer\s(\S+)/);
+    const matches = token.match(/^Bearer\s(\S+)/);
 
     if (!matches) {
       throw new InvalidRequestError(

--- a/test/integration/handlers/authenticate-handler.spec.ts
+++ b/test/integration/handlers/authenticate-handler.spec.ts
@@ -303,7 +303,7 @@ describe('AuthenticateHandler integration', () => {
       const request = new Request({
         body: {},
         headers: {
-          Authorization: 'foobar',
+          Authorization: 'foo Bearer bar',
         },
         method: 'ANY',
         query: {},


### PR DESCRIPTION
The implementation ( lib/handlers/authenticate-handler.ts#L145 )
of the pattern matching for the Bearer token matches only the string
"Bearer" followed by one whitespace character followed by any number of
non-whitespace characters. However, the loophole in the expression is
that one can prefix the Authorization string with any string before the
"Bearer" string and still get away with a successful match.
This means that `fooBearer bar` or `foo Bearer bar` are valid headers
according to the code.

RFC 6750 | OAuth 2.0 Bearer Token Usage | Section 2.1
https://tools.ietf.org/html/rfc6750#section-2.1
specifies that the Authorization header start with the string "Bearer".

This changeset modifies the code and the test case to make the above
examples get thrown as `InvalidRequestError`s