### PR TITLE
Update refresh-token-grant-type.js

### DIFF
--- a/lib/grant-types/refresh-token-grant-type.js
+++ b/lib/grant-types/refresh-token-grant-type.js
@@ -100,7 +100,7 @@ RefreshTokenGrantType.prototype.getRefreshToken = function(request, client) {
         throw new ServerError('Server error: `getRefreshToken()` did not return a `user` object');
       }
 
-      if (token.client.id !== client.id) {
+      if ((token.client.id !== client.id) && (token.client.id !== client.clientId)) {
         throw new InvalidGrantError('Invalid grant: refresh token is invalid');
       }
 


### PR DESCRIPTION
For consistency shouldn't client.id be client.clientId? in:
      if (token.client.id !== client.id) {
        throw new InvalidGrantError('Invalid grant: refresh token is invalid');
      }
Keeping old format with && switch for backwards compatibility:
      if ((token.client.id !== client.id) && (token.client.id !== client.clientId)) {
        throw new InvalidGrantError('Invalid grant: refresh token is invalid');
      }