### PR TITLE
Set WWW-Authenticate header for invalid requests

### DIFF
--- a/lib/handlers/authenticate-handler.js
+++ b/lib/handlers/authenticate-handler.js
@@ -90,6 +90,12 @@ AuthenticateHandler.prototype.handle = function(request, response) {
       // @see https://tools.ietf.org/html/rfc6750#section-3.1
       if (e instanceof UnauthorizedRequestError) {
         response.set('WWW-Authenticate', 'Bearer realm="Service"');
+      } else if (e instanceof InvalidRequestError) {
+        response.set('WWW-Authenticate', 'Bearer realm="Service",error="invalid_request"');
+      } else if (e instanceof InvalidTokenError) {
+        response.set('WWW-Authenticate', 'Bearer realm="Service",error="invalid_token"');
+      } else if (e instanceof InsufficientScopeError) {
+        response.set('WWW-Authenticate', 'Bearer realm="Service",error="insufficient_scope"');
       }
 
       if (!(e instanceof OAuthError)) {

--- a/test/integration/handlers/authenticate-handler_test.js
+++ b/test/integration/handlers/authenticate-handler_test.js
@@ -132,6 +132,57 @@ describe('AuthenticateHandler integration', function() {
         });
     });
 
+    it('should set the `WWW-Authenticate` header if an InvalidRequestError is thrown', function() {
+      var model = {
+        getAccessToken: function() {
+          throw new InvalidRequestError();
+        }
+      };
+      var handler = new AuthenticateHandler({ model: model });
+      var request = new Request({ body: {}, headers: { 'Authorization': 'Bearer foo' }, method: {}, query: {} });
+      var response = new Response({ body: {}, headers: {} });
+
+      return handler.handle(request, response)
+        .then(should.fail)
+        .catch(function() {
+          response.get('WWW-Authenticate').should.equal('Bearer realm="Service",error="invalid_request"');
+        });
+    });
+    
+    it('should set the `WWW-Authenticate` header if an InvalidTokenError is thrown', function() {
+      var model = {
+        getAccessToken: function() {
+          throw new InvalidTokenError();
+        }
+      };
+      var handler = new AuthenticateHandler({ model: model });
+      var request = new Request({ body: {}, headers: { 'Authorization': 'Bearer foo' }, method: {}, query: {} });
+      var response = new Response({ body: {}, headers: {} });
+
+      return handler.handle(request, response)
+        .then(should.fail)
+        .catch(function() {
+          response.get('WWW-Authenticate').should.equal('Bearer realm="Service",error="invalid_token"');
+        });
+    });
+
+    it('should set the `WWW-Authenticate` header if an InsufficientScopeError is thrown', function() {
+      var model = {
+        getAccessToken: function() {
+          throw new InsufficientScopeError();
+        }
+      };
+      var handler = new AuthenticateHandler({ model: model });
+      var request = new Request({ body: {}, headers: { 'Authorization': 'Bearer foo' }, method: {}, query: {} });
+      var response = new Response({ body: {}, headers: {} });
+
+      return handler.handle(request, response)
+        .then(should.fail)
+        .catch(function() {
+          response.get('WWW-Authenticate').should.equal('Bearer realm="Service",error="insufficient_scope"');
+        });
+    });
+
     it('should throw the error if an oauth error is thrown', function() {
       var model = {
         getAccessToken: function() {


### PR DESCRIPTION
This adds the WWW-Authenticate header for InvalidRequestError, InvalidTokenError,
and InsufficientScopeError, as specified in RFC 6750, Section 3

Fixes #553