### PR TITLE
Remove scope validation

### DIFF
--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -176,7 +176,6 @@ AuthorizationCodeGrantType.prototype.revokeAuthorizationCode = function(code) {
 
 AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authorizationCode, scope) {
   var fns = [
-    this.validateScope(user, client, scope),
     this.generateAccessToken(client, user, scope),
     this.generateRefreshToken(client, user, scope),
     this.getAccessTokenExpiresAt(),
@@ -185,7 +184,7 @@ AuthorizationCodeGrantType.prototype.saveToken = function(user, client, authoriz
 
   return Promise.all(fns)
     .bind(this)
-    .spread(function(scope, accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
+    .spread(function(accessToken, refreshToken, accessTokenExpiresAt, refreshTokenExpiresAt) {
       var token = {
         accessToken: accessToken,
         authorizationCode: authorizationCode,

--- a/test/unit/grant-types/authorization-code-grant-type_test.js
+++ b/test/unit/grant-types/authorization-code-grant-type_test.js
@@ -83,6 +83,7 @@ describe('AuthorizationCodeGrantType', function() {
           model.saveToken.firstCall.args[1].should.equal(client);
           model.saveToken.firstCall.args[2].should.equal(user);
           model.saveToken.firstCall.thisValue.should.equal(model);
+          handler.validateScope.callCount.should.equal(0);
         })
         .catch(should.fail);
     });


### PR DESCRIPTION
Remove scope validation when saving token in auth code grant type.

Fixes #631