### PR TITLE
Add PKCE support

### DIFF
--- a/docs/model/spec.rst
+++ b/docs/model/spec.rst
@@ -336,25 +336,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 An ``Object`` representing the authorization code and associated data.
 
-+--------------------+--------+--------------------------------------------------------------+
-| Name               | Type   | Description                                                  |
-+====================+========+==============================================================+
-| code               | Object | The return value.                                            |
-+--------------------+--------+--------------------------------------------------------------+
-| code.code          | String | The authorization code passed to ``getAuthorizationCode()``. |
-+--------------------+--------+--------------------------------------------------------------+
-| code.expiresAt     | Date   | The expiry time of the authorization code.                   |
-+--------------------+--------+--------------------------------------------------------------+
-| [code.redirectUri] | String | The redirect URI of the authorization code.                  |
-+--------------------+--------+--------------------------------------------------------------+
-| [code.scope]       | String | The authorized scope of the authorization code.              |
-+--------------------+--------+--------------------------------------------------------------+
-| code.client        | Object | The client associated with the authorization code.           |
-+--------------------+--------+--------------------------------------------------------------+
-| code.client.id     | String | A unique string identifying the client.                      |
-+--------------------+--------+--------------------------------------------------------------+
-| code.user          | Object | The user associated with the authorization code.             |
-+--------------------+--------+--------------------------------------------------------------+
++----------------------------+--------+---------------------------------------------------------------+
+| Name                       | Type   | Description                                                   |
++============================+========+===============================================================+
+| code                       | Object | The return value.                                             |
++----------------------------+--------+---------------------------------------------------------------+
+| code.code                  | String | The authorization code passed to ``getAuthorizationCode()``.  |
++----------------------------+--------+---------------------------------------------------------------+
+| code.expiresAt             | Date   | The expiry time of the authorization code.                    |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.redirectUri]         | String | The redirect URI of the authorization code.                   |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.scope]               | String | The authorized scope of the authorization code.               |
++----------------------------+--------+---------------------------------------------------------------+
+| code.client                | Object | The client associated with the authorization code.            |
++----------------------------+--------+---------------------------------------------------------------+
+| code.client.id             | String | A unique string identifying the client.                       |
++----------------------------+--------+---------------------------------------------------------------+
+| code.user                  | Object | The user associated with the authorization code.              |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.codeChallenge]       | String | The code challenge string used with PKCE (RFC7636).           |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.codeChallengeMethod] | String | The string for the code challenge method (`S256` or `plain`). |
++----------------------------+--------+---------------------------------------------------------------+
 
 ``code.client`` and ``code.user`` can carry additional properties that will be ignored by *oauth2-server*.
 
@@ -379,7 +383,9 @@ An ``Object`` representing the authorization code and associated data.
           redirectUri: code.redirect_uri,
           scope: code.scope,
           client: client, // with 'id' property
-          user: user
+          user: user,
+          codeChallenge: code.code_challenge,
+          codeChallengeMethod: code.code_challenge_method
         };
       });
   }
@@ -665,25 +671,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 **Arguments:**
 
-+------------------------+----------+---------------------------------------------------------------------+
-| Name                   | Type     | Description                                                         |
-+========================+==========+=====================================================================+
-| code                   | Object   | The code to be saved.                                               |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.authorizationCode | String   | The authorization code to be saved.                                 |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.expiresAt         | Date     | The expiry time of the authorization code.                          |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.redirectUri       | String   | The redirect URI associated with the authorization code.            |
-+------------------------+----------+---------------------------------------------------------------------+
-| [code.scope]           | String   | The authorized scope of the authorization code.                     |
-+------------------------+----------+---------------------------------------------------------------------+
-| client                 | Object   | The client associated with the authorization code.                  |
-+------------------------+----------+---------------------------------------------------------------------+
-| user                   | Object   | The user associated with the authorization code.                    |
-+------------------------+----------+---------------------------------------------------------------------+
-| [callback]             | Function | Node-style callback to be used instead of the returned ``Promise``. |
-+------------------------+----------+---------------------------------------------------------------------+
++----------------------------+----------+---------------------------------------------------------------------+
+| Name                       | Type     | Description                                                         |
++============================+==========+=====================================================================+
+| code                       | Object   | The code to be saved.                                               |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.authorizationCode     | String   | The authorization code to be saved.                                 |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.expiresAt             | Date     | The expiry time of the authorization code.                          |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.redirectUri           | String   | The redirect URI associated with the authorization code.            |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.scope]               | String   | The authorized scope of the authorization code.                     |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.codeChallenge]       | String   | The code challenge string used with PKCE (RFC7636).                 |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.codeChallengeMethod] | String   | The string for the code challenge method (`S256` or `plain`).       |
++----------------------------+----------+---------------------------------------------------------------------+
+| client                     | Object   | The client associated with the authorization code.                  |
++----------------------------+----------+---------------------------------------------------------------------+
+| user                       | Object   | The user associated with the authorization code.                    |
++----------------------------+----------+---------------------------------------------------------------------+
+| [callback]                 | Function | Node-style callback to be used instead of the returned ``Promise``. |
++----------------------------+----------+---------------------------------------------------------------------+
 
 .. todo:: Is ``code.scope`` really optional?
 
@@ -691,25 +701,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 An ``Object`` representing the authorization code and associated data.
 
-+------------------------+--------+---------------------------------------------------------------+
-| Name                   | Type   | Description                                                   |
-+========================+========+===============================================================+
-| code                   | Object | The return value.                                             |
-+------------------------+--------+---------------------------------------------------------------+
-| code.authorizationCode | String | The authorization code passed to ``saveAuthorizationCode()``. |
-+------------------------+--------+---------------------------------------------------------------+
-| code.expiresAt         | Date   | The expiry time of the authorization code.                    |
-+------------------------+--------+---------------------------------------------------------------+
-| code.redirectUri       | String | The redirect URI associated with the authorization code.      |
-+------------------------+--------+---------------------------------------------------------------+
-| [code.scope]           | String | The authorized scope of the authorization code.               |
-+------------------------+--------+---------------------------------------------------------------+
-| code.client            | Object | The client associated with the authorization code.            |
-+------------------------+--------+---------------------------------------------------------------+
-| code.client.id         | String | A unique string identifying the client.                       |
-+------------------------+--------+---------------------------------------------------------------+
-| code.user              | Object | The user associated with the authorization code.              |
-+------------------------+--------+---------------------------------------------------------------+
++----------------------------+--------+----------------------------------------------------------------+
+| Name                       | Type   | Description                                                    |
++============================+========+================================================================+
+| code                       | Object | The return value.                                              |
++----------------------------+--------+----------------------------------------------------------------+
+| code.authorizationCode     | String | The authorization code passed to ``saveAuthorizationCode()``.  |
++----------------------------+--------+----------------------------------------------------------------+
+| code.expiresAt             | Date   | The expiry time of the authorization code.                     |
++----------------------------+--------+----------------------------------------------------------------+
+| code.redirectUri           | String | The redirect URI associated with the authorization code.       |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.scope]               | String | The authorized scope of the authorization code.                |
++----------------------------+--------+----------------------------------------------------------------+
+| code.client                | Object | The client associated with the authorization code.             |
++----------------------------+--------+----------------------------------------------------------------+
+| code.client.id             | String | A unique string identifying the client.                        |
++----------------------------+--------+----------------------------------------------------------------+
+| code.user                  | Object | The user associated with the authorization code.               |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.codeChallenge]       | String | The code challenge string used with PKCE (RFC7636).            |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.codeChallengeMethod] | String | The string for the code challenge method (`S256` or `plain`    |
++----------------------------+--------+----------------------------------------------------------------+
 
 ``code.client`` and ``code.user`` can carry additional properties that will be ignored by *oauth2-server*.
 
@@ -725,7 +739,9 @@ An ``Object`` representing the authorization code and associated data.
       redirect_uri: code.redirectUri,
       scope: code.scope,
       client_id: client.id,
-      user_id: user.id
+      user_id: user.id,
+      code_challenge: code.codeChallenge,
+      code_challenge_method: code.codeChallengeMethod
     };
     return db.saveAuthorizationCode(authCode)
       .then(function(authorizationCode) {
@@ -735,7 +751,9 @@ An ``Object`` representing the authorization code and associated data.
           redirectUri: authorizationCode.redirect_uri,
           scope: authorizationCode.scope,
           client: {id: authorizationCode.client_id},
-          user: {id: authorizationCode.user_id}
+          user: {id: authorizationCode.user_id},
+          codeChallenge: authorizationCode.code_challenge,
+          codeChallengeMethod: authorizationCode.code_challenge_method
         };
       });
   }

--- a/lib/grant-types/authorization-code-grant-type.js
+++ b/lib/grant-types/authorization-code-grant-type.js
@@ -13,6 +13,8 @@ var promisify = require('promisify-any').use(Promise);
 var ServerError = require('../errors/server-error');
 var is = require('../validator/is');
 var util = require('util');
+var crypto = require('crypto');
+var stringUtil = require('../utils/string-util');
 
 /**
  * Constructor.
@@ -116,6 +118,34 @@ AuthorizationCodeGrantType.prototype.getAuthorizationCode = function(request, cl
 
       if (code.redirectUri && !is.uri(code.redirectUri)) {
         throw new InvalidGrantError('Invalid grant: `redirect_uri` is not a valid URI');
+      }
+
+      if (code.codeChallenge) {
+        if (!request.body.code_verifier) {
+          throw new InvalidGrantError('Missing parameter: `code_verifier`');
+        }
+
+        var hash;
+        switch(code.codeChallengeMethod) {
+          case 'plain':
+            hash = request.body.code_verifier;
+            break;
+          case 'S256':
+            hash = stringUtil.base64URLEncode(crypto.createHash('sha256').update(request.body.code_verifier).digest());
+            break;
+          default:
+            throw new ServerError('Server error: `getAuthorizationCode()` did not return a valid `codeChallengeMethod` property');
+        }
+
+        if (code.codeChallenge !== hash) {
+          throw new InvalidGrantError('Invalid grant: code verifier is invalid');
+        }
+      }
+      else {
+        if (request.body.code_verifier) {
+          // No code challenge but code_verifier was passed in.
+          throw new InvalidGrantError('Invalid grant: code verifier is invalid');
+        }
       }
 
       return code;

--- a/lib/handlers/token-handler.js
+++ b/lib/handlers/token-handler.js
@@ -118,12 +118,13 @@ TokenHandler.prototype.handle = function(request, response) {
 TokenHandler.prototype.getClient = function(request, response) {
   var credentials = this.getClientCredentials(request);
   var grantType = request.body.grant_type;
+  var isPkce = this.isPKCERequest(request, grantType);
 
   if (!credentials.clientId) {
     throw new InvalidRequestError('Missing parameter: `client_id`');
   }
 
-  if (this.isClientAuthenticationRequired(grantType) && !credentials.clientSecret) {
+  if (this.isClientAuthenticationRequired(grantType) && !credentials.clientSecret && !isPkce) {
     throw new InvalidRequestError('Missing parameter: `client_secret`');
   }
 
@@ -185,6 +186,12 @@ TokenHandler.prototype.getClientCredentials = function(request) {
 
   if (request.body.client_id && request.body.client_secret) {
     return { clientId: request.body.client_id, clientSecret: request.body.client_secret };
+  }
+
+  if (this.isPKCERequest(request, grantType)) {
+    if(request.body.client_id) {
+      return { clientId: request.body.client_id };
+    }
   }
 
   if (!this.isClientAuthenticationRequired(grantType)) {
@@ -291,6 +298,17 @@ TokenHandler.prototype.isClientAuthenticationRequired = function(grantType) {
   } else {
     return true;
   }
+};
+
+/**
+ * Check if the request is a PCKE request. We assume PKCE if grant type is 'authorization_code'
+ * and code verifier is present.
+ */
+TokenHandler.prototype.isPKCERequest = function(request, grantType) {
+  if (grantType === 'authorization_code' && request.body.code_verifier) {
+    return true;
+  }
+  return false;
 };
 
 /**

--- a/lib/response-types/code-response-type.js
+++ b/lib/response-types/code-response-type.js
@@ -5,6 +5,7 @@
  */
 
 var InvalidArgumentError = require('../errors/invalid-argument-error');
+var InvalidRequestError = require('../errors/invalid-request-error');
 var tokenUtil = require('../utils/token-util');
 var Promise = require('bluebird');
 
@@ -53,6 +54,13 @@ CodeResponseType.prototype.handle = function(request, client, user, uri, scope) 
     throw new InvalidArgumentError('Missing parameter: `uri`');
   }
 
+  var codeChallenge = this.getCodeChallenge(request);
+  var codeChallengeMethod = this.getCodeChallengeMethod(request);
+  
+  if (!codeChallenge && codeChallengeMethod) {
+    throw new InvalidArgumentError('Missing parameter: `code_challenge`');
+  }
+
   var fns = [
     this.generateAuthorizationCode(),
     this.getAuthorizationCodeExpiresAt(client)
@@ -61,7 +69,7 @@ CodeResponseType.prototype.handle = function(request, client, user, uri, scope) 
   return Promise.all(fns)
     .bind(this)
     .spread(function(authorizationCode, expiresAt) {
-      return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, uri, user);
+      return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, uri, user, codeChallenge, codeChallengeMethod);
     })
     .then(function(code) {
       this.code = code.authorizationCode;
@@ -94,13 +102,21 @@ CodeResponseType.prototype.getAuthorizationCodeLifetime = function(client) {
  * Save authorization code.
  */
 
-CodeResponseType.prototype.saveAuthorizationCode = function(authorizationCode, expiresAt, scope, client, redirectUri, user) {
+CodeResponseType.prototype.saveAuthorizationCode = function(authorizationCode, expiresAt, scope, client, redirectUri, user, codeChallenge, codeChallengeMethod) {
   var code = {
     authorizationCode: authorizationCode,
     expiresAt: expiresAt,
     redirectUri: redirectUri,
     scope: scope
   };
+
+  if (codeChallenge) {
+    code.codeChallenge = codeChallenge;
+
+    // Section 4.3 - https://tools.ietf.org/html/rfc7636#section-4
+    // Defaults to "plain" if not present in the request.
+    code.codeChallengeMethod = codeChallengeMethod || 'plain';
+  }
 
   return Promise.try(this.model.saveAuthorizationCode, [code, client, user]);
 };
@@ -115,6 +131,43 @@ CodeResponseType.prototype.generateAuthorizationCode = function() {
   }
 
   return tokenUtil.generateRandomToken();
+};
+
+/**
+ * Get Code challenge
+ */
+CodeResponseType.prototype.getCodeChallenge = function(request) {
+  var codeChallenge = request.body.code_challenge || request.query.code_challenge;
+
+  if (!codeChallenge) {
+    return null;
+  }
+
+  // https://tools.ietf.org/html/rfc7636#section-4
+  if (!codeChallenge.match(/^([A-Za-z0-9\.\-\_\~]){43,128}$/)) {
+    throw new InvalidRequestError('Invalid parameter: `code_challenge`');
+  }
+
+  return codeChallenge;
+};
+
+/**
+ * Get Code challenge method
+ */
+CodeResponseType.prototype.getCodeChallengeMethod = function(request) {
+  var codeChallengeMethod = request.body.code_challenge_method || request.query.code_challenge_method;
+  
+  // https://tools.ietf.org/html/rfc7636#section-4
+  // Section 4.3 - codeChallengeMethod is optional.
+  if (!codeChallengeMethod) {
+    return null;
+  }
+
+  if (codeChallengeMethod !== 'S256' && codeChallengeMethod !== 'plain') {
+    throw new InvalidRequestError('Invalid parameter: `code_challenge_method`');
+  }
+
+  return codeChallengeMethod;
 };
 
 /**

--- a/lib/utils/string-util.js
+++ b/lib/utils/string-util.js
@@ -1,0 +1,14 @@
+'use strict';
+
+/**
+ * Export `StringUtil`.
+ */
+
+module.exports = {
+  base64URLEncode: function(str) {
+    return str.toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+  }
+};

--- a/test/integration/grant-types/authorization-code-grant-type_test.js
+++ b/test/integration/grant-types/authorization-code-grant-type_test.js
@@ -12,6 +12,8 @@ var Promise = require('bluebird');
 var Request = require('../../../lib/request');
 var ServerError = require('../../../lib/errors/server-error');
 var should = require('should');
+var stringUtil = require('../../../lib/utils/string-util');
+var crypto = require('crypto');
 
 /**
  * Test `AuthorizationCodeGrantType` integration.
@@ -359,6 +361,114 @@ describe('AuthorizationCodeGrantType integration', function() {
           e.should.be.an.instanceOf(InvalidGrantError);
           e.message.should.equal('Invalid grant: `redirect_uri` is not a valid URI');
         });
+    });
+
+    describe('with PKCE', function() {
+      it('should throw an error if the `code_verifier` is invalid with S256 code challenge method', function() {
+        var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+        var authorizationCode = {
+          authorizationCode: 12345,
+          client: { id: 'foobar' },
+          expiresAt: new Date(new Date().getTime() * 2),
+          user: {},
+          codeChallengeMethod: 'S256',
+          codeChallenge: stringUtil.base64URLEncode(crypto.createHash('sha256').update(codeVerifier).digest())
+        };
+        var client = { id: 'foobar', isPublic: true };
+        var model = {
+          getAuthorizationCode: function() { return authorizationCode; },
+          revokeAuthorizationCode: function() {},
+          saveToken: function() {}
+        };
+        var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+        var request = new Request({ body: { code: 12345, code_verifier: 'foo' }, headers: {}, method: {}, query: {} });
+
+        return grantType.getAuthorizationCode(request, client)
+          .then(should.fail)
+          .catch(function(e) {
+            e.should.be.an.instanceOf(InvalidGrantError);
+            e.message.should.equal('Invalid grant: code verifier is invalid');
+          });
+      });
+
+      it('should throw an error if the `code_verifier` is invalid with plain code challenge method', function() {
+        var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+        var authorizationCode = {
+          authorizationCode: 12345,
+          client: { id: 'foobar' },
+          expiresAt: new Date(new Date().getTime() * 2),
+          user: {},
+          codeChallengeMethod: 'plain',
+          codeChallenge: codeVerifier
+        };
+        var client = { id: 'foobar', isPublic: true };
+        var model = {
+          getAuthorizationCode: function() { return authorizationCode; },
+          revokeAuthorizationCode: function() {},
+          saveToken: function() {}
+        };
+        var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+        var request = new Request({ body: { code: 12345, code_verifier: 'foo' }, headers: {}, method: {}, query: {} });
+
+        return grantType.getAuthorizationCode(request, client)
+          .then(should.fail)
+          .catch(function(e) {
+            e.should.be.an.instanceOf(InvalidGrantError);
+            e.message.should.equal('Invalid grant: code verifier is invalid');
+          });
+      });
+
+      it('should return an auth code when `code_verifier` is valid with S256 code challenge method', function() {
+        var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+        var authorizationCode = {
+          authorizationCode: 12345,
+          client: { id: 'foobar', isPublic: true },
+          expiresAt: new Date(new Date().getTime() * 2),
+          user: {},
+          codeChallengeMethod: 'S256',
+          codeChallenge: stringUtil.base64URLEncode(crypto.createHash('sha256').update(codeVerifier).digest())
+        };
+        var client = { id: 'foobar', isPublic: true };
+        var model = {
+          getAuthorizationCode: function() { return authorizationCode; },
+          revokeAuthorizationCode: function() {},
+          saveToken: function() {}
+        };
+        var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+        var request = new Request({ body: { code: 12345, code_verifier: codeVerifier }, headers: {}, method: {}, query: {} });
+
+        return grantType.getAuthorizationCode(request, client)
+          .then(function(data) {
+            data.should.equal(authorizationCode);
+          })
+          .catch(should.fail);
+      });
+
+      it('should return an auth code when `code_verifier` is valid with plain code challenge method', function() {
+        var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+        var authorizationCode = {
+          authorizationCode: 12345,
+          client: { id: 'foobar' },
+          expiresAt: new Date(new Date().getTime() * 2),
+          user: {},
+          codeChallengeMethod: 'plain',
+          codeChallenge: codeVerifier
+        };
+        var client = { id: 'foobar', isPublic: true };
+        var model = {
+          getAuthorizationCode: function() { return authorizationCode; },
+          revokeAuthorizationCode: function() {},
+          saveToken: function() {}
+        };
+        var grantType = new AuthorizationCodeGrantType({ accessTokenLifetime: 123, model: model });
+        var request = new Request({ body: { code: 12345, code_verifier: codeVerifier }, headers: {}, method: {}, query: {} });
+
+        return grantType.getAuthorizationCode(request, client)
+          .then(function(data) {
+            data.should.equal(authorizationCode);
+          })
+          .catch(should.fail);
+      });
     });
 
     it('should return an auth code', function() {

--- a/test/integration/handlers/token-handler_test.js
+++ b/test/integration/handlers/token-handler_test.js
@@ -20,6 +20,8 @@ var UnauthorizedClientError = require('../../../lib/errors/unauthorized-client-e
 var UnsupportedGrantTypeError = require('../../../lib/errors/unsupported-grant-type-error');
 var should = require('should');
 var util = require('util');
+var crypto = require('crypto');
+var stringUtil = require('../../../lib/utils/string-util');
 
 /**
  * Test `TokenHandler` integration.
@@ -826,6 +828,197 @@ describe('TokenHandler integration', function() {
             data.should.equal(token);
           })
           .catch(should.fail);
+      });
+
+      describe('with PKCE', function() {
+        it('should return a token when code verifier is valid using S256 code challenge method', function() {
+          var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+          var authorizationCode = {
+            authorizationCode: 12345,
+            client: { id: 'foobar' },
+            expiresAt: new Date(new Date().getTime() * 2),
+            user: {},
+            codeChallengeMethod: 'S256',
+            codeChallenge: stringUtil.base64URLEncode(crypto.createHash('sha256').update(codeVerifier).digest())
+          };
+          var client = { id: 'foobar', grants: ['authorization_code'] };
+          var token = {};
+          var model = {
+            getAuthorizationCode: function() { return authorizationCode; },
+            getClient: function() {},
+            saveToken: function() { return token; },
+            validateScope: function() { return 'foo'; },
+            revokeAuthorizationCode: function() { return authorizationCode; }
+          };
+          var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+          var request = new Request({
+            body: {
+              code: 12345,
+              grant_type: 'authorization_code',
+              code_verifier: codeVerifier
+            },
+            headers: {},
+            method: {},
+            query: {}
+          });
+
+          return handler.handleGrantType(request, client)
+            .then(function(data) {
+              data.should.equal(token);
+            })
+            .catch(should.fail);
+        });
+
+        it('should return a token when code verifier is valid using plain code challenge method', function() {
+          var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+          var authorizationCode = {
+            authorizationCode: 12345,
+            client: { id: 'foobar' },
+            expiresAt: new Date(new Date().getTime() * 2),
+            user: {},
+            codeChallengeMethod: 'plain',
+            codeChallenge: codeVerifier
+          };
+          var client = { id: 'foobar', grants: ['authorization_code'] };
+          var token = {};
+          var model = {
+            getAuthorizationCode: function() { return authorizationCode; },
+            getClient: function() {},
+            saveToken: function() { return token; },
+            validateScope: function() { return 'foo'; },
+            revokeAuthorizationCode: function() { return authorizationCode; }
+          };
+          var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+          var request = new Request({
+            body: {
+              code: 12345,
+              grant_type: 'authorization_code',
+              code_verifier: codeVerifier
+            },
+            headers: {},
+            method: {},
+            query: {}
+          });
+
+          return handler.handleGrantType(request, client)
+            .then(function(data) {
+              data.should.equal(token);
+            })
+            .catch(should.fail);
+        });
+
+        it('should throw an invalid grant error when code verifier is invalid', function() {
+          var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+          var authorizationCode = {
+            authorizationCode: 12345,
+            client: { id: 'foobar' },
+            expiresAt: new Date(new Date().getTime() * 2),
+            user: {},
+            codeChallengeMethod: 'S256',
+            codeChallenge: stringUtil.base64URLEncode(crypto.createHash('sha256').update(codeVerifier).digest())
+          };
+          var client = { id: 'foobar', grants: ['authorization_code'] };
+          var token = {};
+          var model = {
+            getAuthorizationCode: function() { return authorizationCode; },
+            getClient: function() {},
+            saveToken: function() { return token; },
+            validateScope: function() { return 'foo'; },
+            revokeAuthorizationCode: function() { return authorizationCode; }
+          };
+          var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+          var request = new Request({
+            body: {
+              code: 12345,
+              grant_type: 'authorization_code',
+              code_verifier: '123123123123123123123123123123123123123123123'
+            },
+            headers: {},
+            method: {},
+            query: {}
+          });
+
+          return handler.handleGrantType(request, client)
+            .then(should.fail)
+            .catch(function(e) {
+              e.should.be.an.instanceOf(InvalidGrantError);
+              e.message.should.equal('Invalid grant: code verifier is invalid');
+            });
+        });
+
+        it('should throw an invalid grant error when code verifier is missing', function() {
+          var codeVerifier = stringUtil.base64URLEncode(crypto.randomBytes(32));
+          var authorizationCode = {
+            authorizationCode: 12345,
+            client: { id: 'foobar' },
+            expiresAt: new Date(new Date().getTime() * 2),
+            user: {},
+            codeChallengeMethod: 'S256',
+            codeChallenge: stringUtil.base64URLEncode(crypto.createHash('sha256').update(codeVerifier).digest())
+          };
+          var client = { id: 'foobar', grants: ['authorization_code'] };
+          var token = {};
+          var model = {
+            getAuthorizationCode: function() { return authorizationCode; },
+            getClient: function() {},
+            saveToken: function() { return token; },
+            validateScope: function() { return 'foo'; },
+            revokeAuthorizationCode: function() { return authorizationCode; }
+          };
+          var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+          var request = new Request({
+            body: {
+              code: 12345,
+              grant_type: 'authorization_code'
+            },
+            headers: {},
+            method: {},
+            query: {}
+          });
+
+          return handler.handleGrantType(request, client)
+            .then(should.fail)
+            .catch(function(e) {
+              e.should.be.an.instanceOf(InvalidGrantError);
+              e.message.should.equal('Missing parameter: `code_verifier`');
+            });
+        });
+
+        it('should throw an invalid grant error when code verifier is present but code challenge is missing', function() {
+          var authorizationCode = {
+            authorizationCode: 12345,
+            client: { id: 'foobar' },
+            expiresAt: new Date(new Date().getTime() * 2),
+            user: {}
+          };
+          var client = { id: 'foobar', grants: ['authorization_code'] };
+          var token = {};
+          var model = {
+            getAuthorizationCode: function() { return authorizationCode; },
+            getClient: function() {},
+            saveToken: function() { return token; },
+            validateScope: function() { return 'foo'; },
+            revokeAuthorizationCode: function() { return authorizationCode; }
+          };
+          var handler = new TokenHandler({ accessTokenLifetime: 120, model: model, refreshTokenLifetime: 120 });
+          var request = new Request({
+            body: {
+              code: 12345,
+              grant_type: 'authorization_code',
+              code_verifier: '123123123123123123123123123123123123123123123'
+            },
+            headers: {},
+            method: {},
+            query: {}
+          });
+
+          return handler.handleGrantType(request, client)
+            .then(should.fail)
+            .catch(function(e) {
+              e.should.be.an.instanceOf(InvalidGrantError);
+              e.message.should.equal('Invalid grant: code verifier is invalid');
+            });
+        });
       });
     });
 


### PR DESCRIPTION
This pull implements PKCE support (RFC7636).  It is originally based on pull #452, but has been cleaned up a bit.

Summary of changes:

1. PKCE is completely optional. If the PKCE-related parameters (`code_challenge`, `code_challenge_method`, and `code_verifier`) are not passed to the server, the server behaves exactly the same as before. PKCE mode is enabled only when:
- `code_challenge` (and optionally `code_challenge_method`) parameters are included during authorization code grant.
- `code_verifier` parameter is included during token grant.  When `code_verifier` parameter is included, `client_secret` is ignored since we are using PKCE for authentication.
2. This change introduces 2 new optional fields (`codeChallenge` and `codeChallengeMethod`) to the authorization code model. Changes are required to `Model#saveAuthorizationCode` and `Model#getAuthorizationCode` to persist and retrieve these 2 new fields if they are present.
3. 100% backwards compatible with existing implementations. If existing servers do not update the `Model#saveAuthorizationCode` and `Model#getAuthorizationCode` methods, they will continue to work just as they did before the change.
4. Added lots of tests and updated the documentation.

Example of my changes to `saveAuthorizationCode` for a MongoDB model (in Typescript):
```javascript
  const mongoOAuthCodeGrant = {
    code: code.authorizationCode,
    expires_at: code.expiresAt,
    redirect_uri: code.redirectUri,
    scope: code.scope,
    client_id: client.id,
    user_id: userId,
    oauth_client_id: mongoOAuthClient._id,
  };

  if (code.codeChallenge) {
    mongoOAuthCodeGrant.code_challenge = code.codeChallenge;

    if (code.codeChallengeMethod) {
      mongoOAuthCodeGrant.code_challenge_method = code.codeChallengeMethod;
    }
  }

  const saveResult = await db
    .collection(oauthAuthCodeGrantsCollectionName)
    .insertOne(mongoOAuthCodeGrant);
```

Example of my changes to `getAuthorizationCode` for a MongoDB model (in Typescript)
```javascript
  const mongoAuthCodeGrant = await db
    .collection(oauthAuthCodeGrantsCollectionName)
    .findOne({code: authorizationCode});

  const user = await getUserById(mongoAuthCodeGrant.user_id);
  const client = await getClientById(mongoAuthCodeGrant.client_id);
  const grant: OAuthCodeGrant = {
    authorizationCode: mongoAuthCodeGrant.code,
    expiresAt: mongoAuthCodeGrant.expires_at,
    redirectUri: mongoAuthCodeGrant.redirect_uri,
    scope: mongoAuthCodeGrant.scope,
    client: client,
    user: user,
  };

  if (mongoAuthCodeGrant.code_challenge) {
    grant.codeChallenge = mongoAuthCodeGrant.code_challenge;

    if (mongoAuthCodeGrant.code_challenge_method) {
      grant.codeChallengeMethod = mongoAuthCodeGrant.code_challenge_method;
    }
  }
```
