### PR TITLE
Add PKCE support (for v5-dev Typescript)

### DIFF
--- a/docs/model/spec.rst
+++ b/docs/model/spec.rst
@@ -336,25 +336,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 An ``Object`` representing the authorization code and associated data.
 
-+--------------------+--------+--------------------------------------------------------------+
-| Name               | Type   | Description                                                  |
-+====================+========+==============================================================+
-| code               | Object | The return value.                                            |
-+--------------------+--------+--------------------------------------------------------------+
-| code.code          | String | The authorization code passed to ``getAuthorizationCode()``. |
-+--------------------+--------+--------------------------------------------------------------+
-| code.expiresAt     | Date   | The expiry time of the authorization code.                   |
-+--------------------+--------+--------------------------------------------------------------+
-| [code.redirectUri] | String | The redirect URI of the authorization code.                  |
-+--------------------+--------+--------------------------------------------------------------+
-| [code.scope]       | String | The authorized scope of the authorization code.              |
-+--------------------+--------+--------------------------------------------------------------+
-| code.client        | Object | The client associated with the authorization code.           |
-+--------------------+--------+--------------------------------------------------------------+
-| code.client.id     | String | A unique string identifying the client.                      |
-+--------------------+--------+--------------------------------------------------------------+
-| code.user          | Object | The user associated with the authorization code.             |
-+--------------------+--------+--------------------------------------------------------------+
++----------------------------+--------+---------------------------------------------------------------+
+| Name                       | Type   | Description                                                   |
++============================+========+===============================================================+
+| code                       | Object | The return value.                                             |
++----------------------------+--------+---------------------------------------------------------------+
+| code.code                  | String | The authorization code passed to ``getAuthorizationCode()``.  |
++----------------------------+--------+---------------------------------------------------------------+
+| code.expiresAt             | Date   | The expiry time of the authorization code.                    |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.redirectUri]         | String | The redirect URI of the authorization code.                   |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.scope]               | String | The authorized scope of the authorization code.               |
++----------------------------+--------+---------------------------------------------------------------+
+| code.client                | Object | The client associated with the authorization code.            |
++----------------------------+--------+---------------------------------------------------------------+
+| code.client.id             | String | A unique string identifying the client.                       |
++----------------------------+--------+---------------------------------------------------------------+
+| code.user                  | Object | The user associated with the authorization code.              |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.codeChallenge]       | String | The code challenge string used with PKCE (RFC7636).           |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.codeChallengeMethod] | String | The string for the code challenge method (`S256` or `plain`). |
++----------------------------+--------+---------------------------------------------------------------+
 
 ``code.client`` and ``code.user`` can carry additional properties that will be ignored by *oauth2-server*.
 
@@ -379,7 +383,9 @@ An ``Object`` representing the authorization code and associated data.
           redirectUri: code.redirect_uri,
           scope: code.scope,
           client: client, // with 'id' property
-          user: user
+          user: user,
+          codeChallenge: code.code_challenge,
+          codeChallengeMethod: code.code_challenge_method
         };
       });
   }
@@ -665,25 +671,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 **Arguments:**
 
-+------------------------+----------+---------------------------------------------------------------------+
-| Name                   | Type     | Description                                                         |
-+========================+==========+=====================================================================+
-| code                   | Object   | The code to be saved.                                               |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.authorizationCode | String   | The authorization code to be saved.                                 |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.expiresAt         | Date     | The expiry time of the authorization code.                          |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.redirectUri       | String   | The redirect URI associated with the authorization code.            |
-+------------------------+----------+---------------------------------------------------------------------+
-| [code.scope]           | String   | The authorized scope of the authorization code.                     |
-+------------------------+----------+---------------------------------------------------------------------+
-| client                 | Object   | The client associated with the authorization code.                  |
-+------------------------+----------+---------------------------------------------------------------------+
-| user                   | Object   | The user associated with the authorization code.                    |
-+------------------------+----------+---------------------------------------------------------------------+
-| [callback]             | Function | Node-style callback to be used instead of the returned ``Promise``. |
-+------------------------+----------+---------------------------------------------------------------------+
++----------------------------+----------+---------------------------------------------------------------------+
+| Name                       | Type     | Description                                                         |
++============================+==========+=====================================================================+
+| code                       | Object   | The code to be saved.                                               |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.authorizationCode     | String   | The authorization code to be saved.                                 |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.expiresAt             | Date     | The expiry time of the authorization code.                          |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.redirectUri           | String   | The redirect URI associated with the authorization code.            |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.scope]               | String   | The authorized scope of the authorization code.                     |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.codeChallenge]       | String   | The code challenge string used with PKCE (RFC7636).                 |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.codeChallengeMethod] | String   | The string for the code challenge method (`S256` or `plain`).       |
++----------------------------+----------+---------------------------------------------------------------------+
+| client                     | Object   | The client associated with the authorization code.                  |
++----------------------------+----------+---------------------------------------------------------------------+
+| user                       | Object   | The user associated with the authorization code.                    |
++----------------------------+----------+---------------------------------------------------------------------+
+| [callback]                 | Function | Node-style callback to be used instead of the returned ``Promise``. |
++----------------------------+----------+---------------------------------------------------------------------+
 
 .. todo:: Is ``code.scope`` really optional?
 
@@ -691,25 +701,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 An ``Object`` representing the authorization code and associated data.
 
-+------------------------+--------+---------------------------------------------------------------+
-| Name                   | Type   | Description                                                   |
-+========================+========+===============================================================+
-| code                   | Object | The return value.                                             |
-+------------------------+--------+---------------------------------------------------------------+
-| code.authorizationCode | String | The authorization code passed to ``saveAuthorizationCode()``. |
-+------------------------+--------+---------------------------------------------------------------+
-| code.expiresAt         | Date   | The expiry time of the authorization code.                    |
-+------------------------+--------+---------------------------------------------------------------+
-| code.redirectUri       | String | The redirect URI associated with the authorization code.      |
-+------------------------+--------+---------------------------------------------------------------+
-| [code.scope]           | String | The authorized scope of the authorization code.               |
-+------------------------+--------+---------------------------------------------------------------+
-| code.client            | Object | The client associated with the authorization code.            |
-+------------------------+--------+---------------------------------------------------------------+
-| code.client.id         | String | A unique string identifying the client.                       |
-+------------------------+--------+---------------------------------------------------------------+
-| code.user              | Object | The user associated with the authorization code.              |
-+------------------------+--------+---------------------------------------------------------------+
++----------------------------+--------+----------------------------------------------------------------+
+| Name                       | Type   | Description                                                    |
++============================+========+================================================================+
+| code                       | Object | The return value.                                              |
++----------------------------+--------+----------------------------------------------------------------+
+| code.authorizationCode     | String | The authorization code passed to ``saveAuthorizationCode()``.  |
++----------------------------+--------+----------------------------------------------------------------+
+| code.expiresAt             | Date   | The expiry time of the authorization code.                     |
++----------------------------+--------+----------------------------------------------------------------+
+| code.redirectUri           | String | The redirect URI associated with the authorization code.       |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.scope]               | String | The authorized scope of the authorization code.                |
++----------------------------+--------+----------------------------------------------------------------+
+| code.client                | Object | The client associated with the authorization code.             |
++----------------------------+--------+----------------------------------------------------------------+
+| code.client.id             | String | A unique string identifying the client.                        |
++----------------------------+--------+----------------------------------------------------------------+
+| code.user                  | Object | The user associated with the authorization code.               |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.codeChallenge]       | String | The code challenge string used with PKCE (RFC7636).            |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.codeChallengeMethod] | String | The string for the code challenge method (`S256` or `plain`    |
++----------------------------+--------+----------------------------------------------------------------+
 
 ``code.client`` and ``code.user`` can carry additional properties that will be ignored by *oauth2-server*.
 
@@ -725,7 +739,9 @@ An ``Object`` representing the authorization code and associated data.
       redirect_uri: code.redirectUri,
       scope: code.scope,
       client_id: client.id,
-      user_id: user.id
+      user_id: user.id,
+      code_challenge: code.codeChallenge,
+      code_challenge_method: code.codeChallengeMethod
     };
     return db.saveAuthorizationCode(authCode)
       .then(function(authorizationCode) {
@@ -735,7 +751,9 @@ An ``Object`` representing the authorization code and associated data.
           redirectUri: authorizationCode.redirect_uri,
           scope: authorizationCode.scope,
           client: {id: authorizationCode.client_id},
-          user: {id: authorizationCode.user_id}
+          user: {id: authorizationCode.user_id},
+          codeChallenge: authorizationCode.code_challenge,
+          codeChallengeMethod: authorizationCode.code_challenge_method
         };
       });
   }

--- a/lib/interfaces/authorization-code.interface.ts
+++ b/lib/interfaces/authorization-code.interface.ts
@@ -10,5 +10,7 @@ export interface AuthorizationCode {
   scope?: string;
   client: Client;
   user: User;
+  codeChallenge?: string;
+  codeChallengeMethod?: 'S256' | 'plain' | null;
   [key: string]: any;
 }

--- a/lib/utils/string-util.ts
+++ b/lib/utils/string-util.ts
@@ -1,0 +1,6 @@
+export const base64URLEncode = (buf: Buffer) => {
+  return buf.toString('base64')
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=/g, '');
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,6 +64,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@types/basic-auth/-/basic-auth-1.1.2.tgz",
       "integrity": "sha512-NzkkcC+gkkILWaBi3+/z/3do6Ybk6TWeTqV5zCVXmG2KaBoT5YqlJvfqP44HCyDA+Cu58pp7uKAxy/G58se/TA==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }
@@ -77,7 +78,8 @@
     "@types/node": {
       "version": "11.15.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.3.tgz",
-      "integrity": "sha512-5RzvXVietaB8S4dwDjxjltAOHtTO87fiksjqjWGZih97j6KSrdCDaRfmYMNrgrLM87odGBrsTHAl6N3fLraQaw=="
+      "integrity": "sha512-5RzvXVietaB8S4dwDjxjltAOHtTO87fiksjqjWGZih97j6KSrdCDaRfmYMNrgrLM87odGBrsTHAl6N3fLraQaw==",
+      "dev": true
     },
     "@types/sinon": {
       "version": "7.5.1",
@@ -88,12 +90,14 @@
     "@types/statuses": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/@types/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-4zJN5gJH+Km6hA36z8MnOKas6EU0qwxItTXNijYDPuZUsSk4EpIAB56fwnxZIhi3tHx42J7wqNdQTqt49Ar9FQ=="
+      "integrity": "sha512-4zJN5gJH+Km6hA36z8MnOKas6EU0qwxItTXNijYDPuZUsSk4EpIAB56fwnxZIhi3tHx42J7wqNdQTqt49Ar9FQ==",
+      "dev": true
     },
     "@types/type-is": {
       "version": "1.6.3",
       "resolved": "https://registry.npmjs.org/@types/type-is/-/type-is-1.6.3.tgz",
       "integrity": "sha512-PNs5wHaNcBgCQG5nAeeZ7OvosrEsI9O4W2jAOO9BCCg4ux9ZZvH2+0iSCOIDBiKuQsiNS8CBlmfX9f5YBQ22cA==",
+      "dev": true,
       "requires": {
         "@types/node": "*"
       }

--- a/package.json
+++ b/package.json
@@ -66,6 +66,10 @@
   "devDependencies": {
     "@types/mocha": "^5.2.7",
     "@types/sinon": "^7.5.1",
+    "@types/basic-auth": "^1.1.2",
+    "@types/node": "^11.15.3",
+    "@types/statuses": "^1.5.0",
+    "@types/type-is": "^1.6.3",
     "mocha": "^6.2.2",
     "npm-run-all": "^4.1.5",
     "should": "^13.2.3",
@@ -76,10 +80,6 @@
     "typescript": "^3.7.2"
   },
   "dependencies": {
-    "@types/basic-auth": "^1.1.2",
-    "@types/node": "^11.15.3",
-    "@types/statuses": "^1.5.0",
-    "@types/type-is": "^1.6.3",
     "basic-auth": "^2.0.1",
     "statuses": "^1.5.0",
     "tslib": "^1.10.0",

--- a/test/unit/handlers/token-handler.spec.ts
+++ b/test/unit/handlers/token-handler.spec.ts
@@ -1,3 +1,4 @@
+import { Response } from 'lib/response';
 import * as should from 'should';
 import * as sinon from 'sinon';
 import { TokenHandler } from '../../../lib/handlers';
@@ -29,7 +30,7 @@ describe('TokenHandler', () => {
       });
 
       return handler
-        .getClient(request, {})
+        .getClient(request, {} as Response)
         .then(() => {
           model.getClient.callCount.should.equal(1);
           model.getClient.firstCall.args.should.have.length(2);


### PR DESCRIPTION
This pull implements PKCE support (RFC7636).  It is originally based on pull #452, but has been cleaned up a bit. Changes should be almost identical to pull #658, but cleaned up for Typescript.

Summary of changes:

1. PKCE is completely optional. If the PKCE-related parameters (`code_challenge`, `code_challenge_method`, and `code_verifier`) are not passed to the server, the server behaves exactly the same as before. PKCE mode is enabled only when:
- `code_challenge` (and optionally `code_challenge_method`) parameters are included during authorization code grant.
- `code_verifier` parameter is included during token grant.  When `code_verifier` parameter is included, `client_secret` is ignored since we are using PKCE for authentication.
2. This change introduces 2 new optional fields (`codeChallenge` and `codeChallengeMethod`) to the authorization code model. Changes are required to `Model#saveAuthorizationCode` and `Model#getAuthorizationCode` to persist and retrieve these 2 new fields if they are present.
3. 100% backwards compatible with existing implementations. If existing servers do not update the `Model#saveAuthorizationCode` and `Model#getAuthorizationCode` methods, they will continue to work just as they did before the change.
4. Added lots of tests and updated the documentation.

Example of my changes to `saveAuthorizationCode` for a MongoDB model (in Typescript):
```javascript
  const mongoOAuthCodeGrant = {
    code: code.authorizationCode,
    expires_at: code.expiresAt,
    redirect_uri: code.redirectUri,
    scope: code.scope,
    client_id: client.id,
    user_id: userId,
    oauth_client_id: mongoOAuthClient._id,
  };

  if (code.codeChallenge) {
    mongoOAuthCodeGrant.code_challenge = code.codeChallenge;

    if (code.codeChallengeMethod) {
      mongoOAuthCodeGrant.code_challenge_method = code.codeChallengeMethod;
    }
  }

  const saveResult = await db
    .collection(oauthAuthCodeGrantsCollectionName)
    .insertOne(mongoOAuthCodeGrant);
```

Example of my changes to `getAuthorizationCode` for a MongoDB model (in Typescript)
```javascript
  const mongoAuthCodeGrant = await db
    .collection(oauthAuthCodeGrantsCollectionName)
    .findOne({code: authorizationCode});

  const user = await getUserById(mongoAuthCodeGrant.user_id);
  const client = await getClientById(mongoAuthCodeGrant.client_id);
  const grant: OAuthCodeGrant = {
    authorizationCode: mongoAuthCodeGrant.code,
    expiresAt: mongoAuthCodeGrant.expires_at,
    redirectUri: mongoAuthCodeGrant.redirect_uri,
    scope: mongoAuthCodeGrant.scope,
    client: client,
    user: user,
  };

  if (mongoAuthCodeGrant.code_challenge) {
    grant.codeChallenge = mongoAuthCodeGrant.code_challenge;

    if (mongoAuthCodeGrant.code_challenge_method) {
      grant.codeChallengeMethod = mongoAuthCodeGrant.code_challenge_method;
    }
  }
```
