### PR TITLE
Fix model spec to use `code.authorizationCode` instead of `code.code`

### DIFF
--- a/docs/model/spec.rst
+++ b/docs/model/spec.rst
@@ -336,25 +336,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 An ``Object`` representing the authorization code and associated data.
 
-+--------------------+--------+--------------------------------------------------------------+
-| Name               | Type   | Description                                                  |
-+====================+========+==============================================================+
-| code               | Object | The return value.                                            |
-+--------------------+--------+--------------------------------------------------------------+
-| code.code          | String | The authorization code passed to ``getAuthorizationCode()``. |
-+--------------------+--------+--------------------------------------------------------------+
-| code.expiresAt     | Date   | The expiry time of the authorization code.                   |
-+--------------------+--------+--------------------------------------------------------------+
-| [code.redirectUri] | String | The redirect URI of the authorization code.                  |
-+--------------------+--------+--------------------------------------------------------------+
-| [code.scope]       | String | The authorized scope of the authorization code.              |
-+--------------------+--------+--------------------------------------------------------------+
-| code.client        | Object | The client associated with the authorization code.           |
-+--------------------+--------+--------------------------------------------------------------+
-| code.client.id     | String | A unique string identifying the client.                      |
-+--------------------+--------+--------------------------------------------------------------+
-| code.user          | Object | The user associated with the authorization code.             |
-+--------------------+--------+--------------------------------------------------------------+
++----------------------------+--------+---------------------------------------------------------------+
+| Name                       | Type   | Description                                                   |
++============================+========+===============================================================+
+| code                       | Object | The return value.                                             |
++----------------------------+--------+---------------------------------------------------------------+
+| code.authorizationCode     | String | The authorization code passed to ``getAuthorizationCode()``.  |
++----------------------------+--------+---------------------------------------------------------------+
+| code.expiresAt             | Date   | The expiry time of the authorization code.                    |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.redirectUri]         | String | The redirect URI of the authorization code.                   |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.scope]               | String | The authorized scope of the authorization code.               |
++----------------------------+--------+---------------------------------------------------------------+
+| code.client                | Object | The client associated with the authorization code.            |
++----------------------------+--------+---------------------------------------------------------------+
+| code.client.id             | String | A unique string identifying the client.                       |
++----------------------------+--------+---------------------------------------------------------------+
+| code.user                  | Object | The user associated with the authorization code.              |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.codeChallenge]       | String | The code challenge string used with PKCE (RFC7636).           |
++----------------------------+--------+---------------------------------------------------------------+
+| [code.codeChallengeMethod] | String | The string for the code challenge method (`S256` or `plain`). |
++----------------------------+--------+---------------------------------------------------------------+
 
 ``code.client`` and ``code.user`` can carry additional properties that will be ignored by *oauth2-server*.
 
@@ -379,7 +383,9 @@ An ``Object`` representing the authorization code and associated data.
           redirectUri: code.redirect_uri,
           scope: code.scope,
           client: client, // with 'id' property
-          user: user
+          user: user,
+          codeChallenge: code.code_challenge,
+          codeChallengeMethod: code.code_challenge_method
         };
       });
   }
@@ -665,25 +671,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 **Arguments:**
 
-+------------------------+----------+---------------------------------------------------------------------+
-| Name                   | Type     | Description                                                         |
-+========================+==========+=====================================================================+
-| code                   | Object   | The code to be saved.                                               |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.authorizationCode | String   | The authorization code to be saved.                                 |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.expiresAt         | Date     | The expiry time of the authorization code.                          |
-+------------------------+----------+---------------------------------------------------------------------+
-| code.redirectUri       | String   | The redirect URI associated with the authorization code.            |
-+------------------------+----------+---------------------------------------------------------------------+
-| [code.scope]           | String   | The authorized scope of the authorization code.                     |
-+------------------------+----------+---------------------------------------------------------------------+
-| client                 | Object   | The client associated with the authorization code.                  |
-+------------------------+----------+---------------------------------------------------------------------+
-| user                   | Object   | The user associated with the authorization code.                    |
-+------------------------+----------+---------------------------------------------------------------------+
-| [callback]             | Function | Node-style callback to be used instead of the returned ``Promise``. |
-+------------------------+----------+---------------------------------------------------------------------+
++----------------------------+----------+---------------------------------------------------------------------+
+| Name                       | Type     | Description                                                         |
++============================+==========+=====================================================================+
+| code                       | Object   | The code to be saved.                                               |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.authorizationCode     | String   | The authorization code to be saved.                                 |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.expiresAt             | Date     | The expiry time of the authorization code.                          |
++----------------------------+----------+---------------------------------------------------------------------+
+| code.redirectUri           | String   | The redirect URI associated with the authorization code.            |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.scope]               | String   | The authorized scope of the authorization code.                     |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.codeChallenge]       | String   | The code challenge string used with PKCE (RFC7636).                 |
++----------------------------+----------+---------------------------------------------------------------------+
+| [code.codeChallengeMethod] | String   | The string for the code challenge method (`S256` or `plain`).       |
++----------------------------+----------+---------------------------------------------------------------------+
+| client                     | Object   | The client associated with the authorization code.                  |
++----------------------------+----------+---------------------------------------------------------------------+
+| user                       | Object   | The user associated with the authorization code.                    |
++----------------------------+----------+---------------------------------------------------------------------+
+| [callback]                 | Function | Node-style callback to be used instead of the returned ``Promise``. |
++----------------------------+----------+---------------------------------------------------------------------+
 
 .. todo:: Is ``code.scope`` really optional?
 
@@ -691,25 +701,29 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 An ``Object`` representing the authorization code and associated data.
 
-+------------------------+--------+---------------------------------------------------------------+
-| Name                   | Type   | Description                                                   |
-+========================+========+===============================================================+
-| code                   | Object | The return value.                                             |
-+------------------------+--------+---------------------------------------------------------------+
-| code.authorizationCode | String | The authorization code passed to ``saveAuthorizationCode()``. |
-+------------------------+--------+---------------------------------------------------------------+
-| code.expiresAt         | Date   | The expiry time of the authorization code.                    |
-+------------------------+--------+---------------------------------------------------------------+
-| code.redirectUri       | String | The redirect URI associated with the authorization code.      |
-+------------------------+--------+---------------------------------------------------------------+
-| [code.scope]           | String | The authorized scope of the authorization code.               |
-+------------------------+--------+---------------------------------------------------------------+
-| code.client            | Object | The client associated with the authorization code.            |
-+------------------------+--------+---------------------------------------------------------------+
-| code.client.id         | String | A unique string identifying the client.                       |
-+------------------------+--------+---------------------------------------------------------------+
-| code.user              | Object | The user associated with the authorization code.              |
-+------------------------+--------+---------------------------------------------------------------+
++----------------------------+--------+----------------------------------------------------------------+
+| Name                       | Type   | Description                                                    |
++============================+========+================================================================+
+| code                       | Object | The return value.                                              |
++----------------------------+--------+----------------------------------------------------------------+
+| code.authorizationCode     | String | The authorization code passed to ``saveAuthorizationCode()``.  |
++----------------------------+--------+----------------------------------------------------------------+
+| code.expiresAt             | Date   | The expiry time of the authorization code.                     |
++----------------------------+--------+----------------------------------------------------------------+
+| code.redirectUri           | String | The redirect URI associated with the authorization code.       |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.scope]               | String | The authorized scope of the authorization code.                |
++----------------------------+--------+----------------------------------------------------------------+
+| code.client                | Object | The client associated with the authorization code.             |
++----------------------------+--------+----------------------------------------------------------------+
+| code.client.id             | String | A unique string identifying the client.                        |
++----------------------------+--------+----------------------------------------------------------------+
+| code.user                  | Object | The user associated with the authorization code.               |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.codeChallenge]       | String | The code challenge string used with PKCE (RFC7636).            |
++----------------------------+--------+----------------------------------------------------------------+
+| [code.codeChallengeMethod] | String | The string for the code challenge method (`S256` or `plain`    |
++----------------------------+--------+----------------------------------------------------------------+
 
 ``code.client`` and ``code.user`` can carry additional properties that will be ignored by *oauth2-server*.
 
@@ -725,7 +739,9 @@ An ``Object`` representing the authorization code and associated data.
       redirect_uri: code.redirectUri,
       scope: code.scope,
       client_id: client.id,
-      user_id: user.id
+      user_id: user.id,
+      code_challenge: code.codeChallenge,
+      code_challenge_method: code.codeChallengeMethod
     };
     return db.saveAuthorizationCode(authCode)
       .then(function(authorizationCode) {
@@ -735,7 +751,9 @@ An ``Object`` representing the authorization code and associated data.
           redirectUri: authorizationCode.redirect_uri,
           scope: authorizationCode.scope,
           client: {id: authorizationCode.client_id},
-          user: {id: authorizationCode.user_id}
+          user: {id: authorizationCode.user_id},
+          codeChallenge: authorizationCode.code_challenge,
+          codeChallengeMethod: authorizationCode.code_challenge_method
         };
       });
   }
@@ -812,27 +830,27 @@ This model function is **required** if the ``authorization_code`` grant is used.
 
 **Arguments:**
 
-+--------------------+----------+---------------------------------------------------------------------+
-| Name               | Type     | Description                                                         |
-+====================+==========+=====================================================================+
-| code               | Object   | The return value.                                                   |
-+--------------------+----------+---------------------------------------------------------------------+
-| code.code          | String   | The authorization code.                                             |
-+--------------------+----------+---------------------------------------------------------------------+
-| code.expiresAt     | Date     | The expiry time of the authorization code.                          |
-+--------------------+----------+---------------------------------------------------------------------+
-| [code.redirectUri] | String   | The redirect URI of the authorization code.                         |
-+--------------------+----------+---------------------------------------------------------------------+
-| [code.scope]       | String   | The authorized scope of the authorization code.                     |
-+--------------------+----------+---------------------------------------------------------------------+
-| code.client        | Object   | The client associated with the authorization code.                  |
-+--------------------+----------+---------------------------------------------------------------------+
-| code.client.id     | String   | A unique string identifying the client.                             |
-+--------------------+----------+---------------------------------------------------------------------+
-| code.user          | Object   | The user associated with the authorization code.                    |
-+--------------------+----------+---------------------------------------------------------------------+
-| [callback]         | Function | Node-style callback to be used instead of the returned ``Promise``. |
-+--------------------+----------+---------------------------------------------------------------------+
++------------------------+----------+---------------------------------------------------------------------+
+| Name                   | Type     | Description                                                         |
++========================+==========+=====================================================================+
+| code                   | Object   | The return value.                                                   |
++------------------------+----------+---------------------------------------------------------------------+
+| code.authorizationCode | String   | The authorization code.                                             |
++------------------------+----------+---------------------------------------------------------------------+
+| code.expiresAt         | Date     | The expiry time of the authorization code.                          |
++------------------------+----------+---------------------------------------------------------------------+
+| [code.redirectUri]     | String   | The redirect URI of the authorization code.                         |
++------------------------+----------+---------------------------------------------------------------------+
+| [code.scope]           | String   | The authorized scope of the authorization code.                     |
++------------------------+----------+---------------------------------------------------------------------+
+| code.client            | Object   | The client associated with the authorization code.                  |
++------------------------+----------+---------------------------------------------------------------------+
+| code.client.id         | String   | A unique string identifying the client.                             |
++------------------------+----------+---------------------------------------------------------------------+
+| code.user              | Object   | The user associated with the authorization code.                    |
++------------------------+----------+---------------------------------------------------------------------+
+| [callback]             | Function | Node-style callback to be used instead of the returned ``Promise``. |
++------------------------+----------+---------------------------------------------------------------------+
 
 **Return value:**
 


### PR DESCRIPTION
`code.authorizationCode` is used everywhere in the source. Therefore, this pull is to correct the spec.rst so that people don't implement the model incorrectly and/or keep opening bugs to correct the code (for example pull #648, issue #557).