### PR TITLE
Only require 'redirect_uri' in token/authorization_code when one was provided in authorize/code

### DIFF
--- a/lib/handlers/authorize-handler.js
+++ b/lib/handlers/authorize-handler.js
@@ -91,7 +91,7 @@ AuthorizeHandler.prototype.handle = function(request, response) {
   return Promise.all(fns)
     .bind(this)
     .spread(function(expiresAt, client, user) {
-      var uri = this.getRedirectUri(request, client);
+      var { uri, requestUri } = this.getRedirectUri(request, client);
       var scope;
       var state;
       var ResponseType;
@@ -111,7 +111,7 @@ AuthorizeHandler.prototype.handle = function(request, response) {
           state = this.getState(request);
           ResponseType = this.getResponseType(request);
 
-          return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, uri, user);
+          return this.saveAuthorizationCode(authorizationCode, expiresAt, scope, client, requestUri, user);
         })
         .then(function(code) {
           var responseType = new ResponseType(code.authorizationCode);
@@ -273,7 +273,10 @@ AuthorizeHandler.prototype.getUser = function(request, response) {
  */
 
 AuthorizeHandler.prototype.getRedirectUri = function(request, client) {
-  return request.body.redirect_uri || request.query.redirect_uri || client.redirectUris[0];
+  var requestUri = request.body.redirect_uri || request.query.redirect_uri;
+  var uri = requestUri || client.redirectUris[0];
+
+  return { uri, requestUri };
 };
 
 /**


### PR DESCRIPTION
This PR is to prevent redirect_uri being saved using saveAuthorizationCode when its not directly requested, this is so that [AuthorizationCodeGrantType#validateRedirectUri](https://github.com/oauthjs/node-oauth2-server/blob/master/lib/grant-types/authorization-code-grant-type.js#L136) does not try to validate against the fallback of `client.redirectUris[0]` 

This is the comment that made me think this makes sense:
https://github.com/oauthjs/node-oauth2-server/blob/master/lib/grant-types/authorization-code-grant-type.js#L125-L134